### PR TITLE
Nerfs plasma weapons and remove plasrifle blueprint from lootdrop table

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -425,7 +425,7 @@
 	name = "tier 5 armor"
 	loot = list(
 				/obj/effect/spawner/bundle/f13/armor/t45d,
-				/obj/effect/spawner/bundle/f13/armor/t51b
+				/obj/effect/spawner/bundle/f13/armor/t51b,
 				)
 
 /obj/effect/spawner/bundle/f13/armor/t45d

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -425,7 +425,7 @@
 	name = "tier 5 armor"
 	loot = list(
 				/obj/effect/spawner/bundle/f13/armor/t45d,
-				/obj/effect/spawner/bundle/f13/armor/t51b				
+				/obj/effect/spawner/bundle/f13/armor/t51b
 				)
 
 /obj/effect/spawner/bundle/f13/armor/t45d
@@ -1817,7 +1817,6 @@
 	icon_state = "blueprint_loot"
 	lootcount = 1
 	loot = list(
-		/obj/item/book/granter/crafting_recipe/blueprint/plasmarifle,
 		/obj/item/book/granter/crafting_recipe/blueprint/am_rifle,
 		/obj/item/book/granter/crafting_recipe/blueprint/citykiller,
 		/obj/item/book/granter/crafting_recipe/blueprint/rangemaster

--- a/code/modules/mob/living/simple_animal/hostile/f13/supermutant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/supermutant.dm
@@ -251,7 +251,3 @@
 	icon_state = icon_dead
 	anchored = FALSE
 	..()
-	var/turf/T = get_turf(src)
-	if(prob(40))
-		new /obj/item/gun/energy/laser/plasma(T)
-	. = ..()

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -337,7 +337,7 @@
 	name = "plasma bolt"
 	icon_state = "plasma_clot"
 	damage_type = BURN
-	damage = 36
+	damage = 46
 	armour_penetration = 0.5
 	flag = "laser" //checks vs. energy protection
 	eyeblur = 0
@@ -348,7 +348,7 @@
 	name = "plasma bolt"
 	icon_state = "plasma_clot"
 	damage_type = BURN
-	damage = 32
+	damage = 38
 	armour_penetration = 0.5
 	flag = "laser" //checks vs. energy protection
 	eyeblur = 0
@@ -366,11 +366,11 @@
 	is_reflectable = FALSE
 
 /obj/item/projectile/f13plasma/pistol //Plasma pistol
-	damage = 36
+	damage = 42
 	armour_penetration = 0.35
 
 /obj/item/projectile/f13plasma/pistol/glock //Glock (streamlined plasma pistol)
-	damage = 32
+	damage = 38
 	armour_penetration = 0.5
 
 /obj/item/projectile/f13plasma/scatter //Multiplas, fires 3 shots, will melt you

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -337,8 +337,8 @@
 	name = "plasma bolt"
 	icon_state = "plasma_clot"
 	damage_type = BURN
-	damage = 55
-	armour_penetration = 0.55
+	damage = 36
+	armour_penetration = 0.5
 	flag = "laser" //checks vs. energy protection
 	eyeblur = 0
 	is_reflectable = TRUE
@@ -348,8 +348,8 @@
 	name = "plasma bolt"
 	icon_state = "plasma_clot"
 	damage_type = BURN
-	damage = 45
-	armour_penetration = 0.55
+	damage = 32
+	armour_penetration = 0.5
 	flag = "laser" //checks vs. energy protection
 	eyeblur = 0
 	is_reflectable = TRUE
@@ -366,15 +366,15 @@
 	is_reflectable = FALSE
 
 /obj/item/projectile/f13plasma/pistol //Plasma pistol
-	damage = 53
+	damage = 36
 	armour_penetration = 0.35
 
 /obj/item/projectile/f13plasma/pistol/glock //Glock (streamlined plasma pistol)
-	damage = 45
+	damage = 32
 	armour_penetration = 0.5
 
 /obj/item/projectile/f13plasma/scatter //Multiplas, fires 3 shots, will melt you
-	damage = 25
+	damage = 24
 	armour_penetration = 0.35
 
 /obj/item/projectile/beam/laser/rcw //RCW


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Damage of most plasma weapons is lowered a bit, and so is the armor penetration.
Plasma rifle blueprint can no longer spawn in random blueprints lootdrop spawner.

## Why It's Good For The Game

Plasma rifles had 50+ damage with 55% AP. What does it mean? It means insta-kill in 2 shots, 3 if you are wearing tier 10+ armor.
Now, that would've not been an issue if it was some sort of sniper rifle with slow rate of fire, but no, that shit can shoot ~4 times a second.
I think it will be only better for the game if we didn't have a weapon capable of killing everything in 2 hits.

## Changelog
:cl:
tweak: Plasma rifle blueprint can no longer randomly spawn.
balance: Plasma weaponry has less damage and armor penetration overall.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
