### PR TITLE
RAT UPDATE

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -443,7 +443,7 @@
 	min_val = 0
 
 /datum/config_entry/number/ratcap
-	config_entry_value = 64
+	config_entry_value = 128
 	min_val = 0
 
 /datum/config_entry/flag/disable_stambuffer


### PR DESCRIPTION
Increases the maximum amount of rats from 64 to 128, doubling it. Why? the wasteland needs more rats.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Simply enough, increases the maximum amount of rats possible from 64 to 128
## Why It's Good For The Game
More rat cooking, such as rat kebabs, and rat burgers. more incentive to farm rats for food.
## Changelog
:cl:
Maximum amount of rats (mice) Increased from 64 to 128
/:cl:

=
