### PR TITLE
Removes Hard Yards from Head Knight

### DIFF
--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -289,7 +289,6 @@ Head Knight
 		return
 	ADD_TRAIT(H, TRAIT_CHEMWHIZ, src)
 	ADD_TRAIT(H, TRAIT_PA_WEAR, src)
-	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
 
 /datum/outfit/job/bos/f13knightcap
 	name = "Head Knight"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes ranger training/hard yards from head knight round start

## Why It's Good For The Game

Head knight is moreso a sedentary job than senior knight, who actually leaves the base sometimes, and shouldn't have it.  It will also discourage head knights from leaving the base.

## Changelog
🆑 
del: Removed trait:  hard yards from head knight role
/:cl:
