### PR TITLE
Replaces detective's .357 with .38

### DIFF
--- a/code/modules/jobs/job_types/den.dm
+++ b/code/modules/jobs/job_types/den.dm
@@ -668,7 +668,7 @@ Mayor
 		/obj/item/detective_scanner=1,
 		/obj/item/storage/box/gloves=1,
 		/obj/item/storage/box/evidence=1,
-		/obj/item/ammo_box/a357=2)
+		/obj/item/ammo_box/c38=2)
 
 /*--------------------------------------------------------------*/
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replaces the two .357 speedloaders the detective starts with and gives him .38 speedloaders.

## Why It's Good For The Game

This irked me for the longest time and no one changed it.  The detective has a .38 revolver, not a .357 revolver.

## Changelog
:cl:
tweak: replaced Detective's speedloaders with ones he can actually use.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
