### PR TITLE
Readds plasma rifle spawn to elite nightkin

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/f13/supermutant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/supermutant.dm
@@ -251,3 +251,7 @@
 	icon_state = icon_dead
 	anchored = FALSE
 	..()
+	var/turf/T = get_turf(src)
+	if(prob(40))
+		new /obj/item/gun/energy/laser/plasma(T)
+	. = ..()


### PR DESCRIPTION

## About The Pull Request

Reverts Egor removing the elite nightkin plasma rifle spawn

## Why It's Good For The Game

Making the weapon extremely rare is dumb when it already got nerfed

## Changelog
:cl:
balance: Readds plasma rifle spawn to elite nightkin
/:cl:
