### PR TITLE
Hunting Knives Given to Brotherhood Combat Roles

### DIFF
--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -147,7 +147,7 @@ Head Paladin
 	id = 			/obj/item/card/id/dogtag
 	neck = 			/obj/item/clothing/neck/cloak/bos/paladin
 	backpack_contents = list(
-		/obj/item/melee/onehanded/knife/survival = 1,
+		/obj/item/kitchen/knife/combat = 1,
 		/obj/item/gun/ballistic/automatic/pistol/n99 = 1,
 		/obj/item/ammo_box/magazine/m10mm_adv/simple = 2,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak/super = 1,
@@ -306,7 +306,7 @@ Head Knight
 	head =			/obj/item/clothing/head/helmet/f13/combat/brotherhood/captain
 	id =			/obj/item/card/id/dogtag
 	backpack_contents = list(
-		/obj/item/melee/onehanded/knife/survival = 1,
+		/obj/item/kitchen/knife/combat = 1,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak/super = 1,
 		)
 
@@ -387,7 +387,7 @@ Star Paladin
 	backpack_contents = list(
 		/obj/item/gun/energy/laser/plasma/pistol = 1,
 		/obj/item/stock_parts/cell/ammo/ec = 2,
-		/obj/item/melee/onehanded/knife/survival = 1,
+		/obj/item/kitchen/knife/combat = 1,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak/super = 1,
 	)
 
@@ -462,7 +462,7 @@ Paladin
 	belt = 			/obj/item/storage/belt/military
 	neck = /obj/item/clothing/neck/cloak/bos/paladin
 	backpack_contents = list(
-		/obj/item/melee/onehanded/knife/survival=1,
+		/obj/item/kitchen/knife/combat=1,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak/super=1
 		)
 
@@ -667,7 +667,7 @@ datum/job/bos/f13seniorknight
 	gunsmith_three = TRUE
 	gunsmith_four = TRUE
 	backpack_contents = list(
-		/obj/item/melee/onehanded/knife/survival=1,
+		/obj/item/kitchen/knife/combat=1,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak/super=1
 		)
 	
@@ -731,7 +731,7 @@ Knight
 	gunsmith_three = TRUE
 	gunsmith_four = TRUE
 	backpack_contents = list(
-		/obj/item/melee/onehanded/knife/survival=1,
+		/obj/item/kitchen/knife/combat=1,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak/super=1
 		)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Currently all Brotherhood roles are given survival knives at start.  These have been changed into slightly better hunting knives for combat roles.  Scribes and initiates are still given survival knives.

## Why It's Good For The Game

This is for convenience and is not a clear buff, as there are enough hunting knives in the armory to go around.  This just saves a second of time and prevents survival knives from being left in odd places.

## Changelog
:cl:
fix: Changed survival knives into hunting knives for Brotherhood combat roles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
