### PR TITLE
Enclave remnants can craft Enclave armor and dogtags

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_misc.dm
+++ b/code/datums/components/crafting/recipes/recipes_misc.dm
@@ -8,6 +8,19 @@
 	subcategory = CAT_MISCELLANEOUS
 	category = CAT_MISC
 
+/datum/crafting_recipe/enclavedogtags
+	name = "Enclave dogtags"
+	result = /obj/item/card/id/dogtag/enclave/recruit/remnant
+	blacklist = list(/obj/item/clothing/suit/armor/f13/combat)
+	reqs = list(/obj/item/card/id/rusted/brokenholodog/enclave = 1,
+				/obj/item/stack/crafting/electronicparts = 5,
+				/obj/item/stack/crafting/goodparts = 3)
+	time = 120
+	tools = list(TOOL_SCREWDRIVER,TOOL_MULTITOOL,TOOL_WORKBENCH)
+	subcategory = CAT_MISCELLANEOUS
+	category = CAT_MISC
+	always_availible = FALSE
+
 /////////////////
 //Large Objects//
 /////////////////

--- a/code/datums/components/crafting/recipes/recipes_tailoring.dm
+++ b/code/datums/components/crafting/recipes/recipes_tailoring.dm
@@ -317,6 +317,28 @@
 	subcategory = CAT_ARMOR
 	always_availible = FALSE
 
+/datum/crafting_recipe/enclavecombatarmor
+	name = "Enclave combat armor"
+	result = /obj/item/clothing/suit/armor/f13/combat/mk2/enclave
+	blacklist = list(/obj/item/clothing/suit/armor/f13/combat)
+	reqs = list(/obj/item/clothing/suit/armor/f13/combat/mk2 = 1,
+				/obj/item/toy/crayon/spraycan)
+	time = 30
+	category = CAT_CLOTHING
+	subcategory = CAT_ARMOR
+	always_availible = FALSE
+
+/datum/crafting_recipe/enclavecombathelmet
+	name = "Enclave combat helmet"
+	result = /obj/item/clothing/head/helmet/f13/combat/mk2/enclave
+	blacklist = list(/obj/item/clothing/head/helmet/f13/combat)
+	reqs = list(/obj/item/clothing/head/helmet/f13/combat/mk2 = 1,
+				/obj/item/toy/crayon/spraycan)
+	time = 30
+	category = CAT_CLOTHING
+	subcategory = CAT_ARMOR
+	always_availible = FALSE
+
 /datum/crafting_recipe/durathread_vest
 	name = "Makeshift Durathread Armour"
 	result = /obj/item/clothing/suit/armor/vest/durathread

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -850,18 +850,28 @@
 	desc = "An advanced holographic dogtag, that shows the duty of a BoS member. This one seems a bit off somewhow..."
 
 /obj/item/card/id/dogtag/enclave/recruit
+	var/set_assignment = "Enclave Recruit"
+	var/change_one_use = FALSE // Can it be used once or more?
+	var/change_used = FALSE // For variable above
 	access = list(ACCESS_ENCLAVE)
 
 /obj/item/card/id/dogtag/enclave/recruit/attack_self(mob/user)
-	if(isliving(user))
+	if(isliving(user) && !change_used)
 		var/mob/living/living_user = user
 		if(alert(user, "Action", "Agent ID", "Show", "Forge") == "Forge")
 			registered_name = living_user.real_name
-			assignment = "Enclave Recruit"
+			assignment = set_assignment
 			update_label()
 			to_chat(user, "<span class='notice'>You successfully update your holotag.</span>")
+			if(change_one_use)
+				change_used = TRUE
 			return
 	..()
+
+/obj/item/card/id/dogtag/enclave/recruit/remnant // A craftable ID for the remnant loadout with a bit more vague assignment and only one use
+	desc = "A restored holographic dogtag, worn by a proud member of the US military, presumably."
+	set_assignment = "Enclave Soldier"
+	change_one_use = TRUE
 
 /obj/item/card/id/selfassign/attack_self(mob/user)
 	if(isliving(user))

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -788,6 +788,16 @@
 	icon_state = "blueprint2"
 	crafting_recipe_types = list(/datum/crafting_recipe/scoutcarbine)
 
+/obj/item/book/granter/crafting_recipe/enclave_armor
+	name = "United States Military maintenance guide"
+	desc = "A short guide on modifying combat armor and repairing the dogtags."
+	icon_state = "book"
+	oneuse = TRUE
+	pages_to_mastery = 2
+	time_per_page = 10
+	remarks = list("Apply paint to the plates...", "Avoid painting the inner side of the armor...", "Do not apply water to the dogtags under any circumstances...", "Broken electronic parts in the dogtag should be all replaced...")
+	crafting_recipe_types = list(/datum/crafting_recipe/enclavecombatarmor, /datum/crafting_recipe/enclavecombathelmet, /datum/crafting_recipe/enclavedogtags)
+
 /obj/item/book/granter/trait/forgemaster
 	name = "Ashes of Phoenix: Imperial Weaponsmithing"
 	desc = "Bound in doghide, this book holds lessons from freemen in tributary cities on how to properly maintain and forge new weapons."
@@ -813,7 +823,7 @@
 	granted_trait = TRAIT_BIG_LEAGUES
 	traitname = "big_leagues"
 	remarks = list("Grognak hit the Death Knight only once, but that was enough.", "Grognak is surprisingly agile, never committing too heavily on an attack, dancing between his enemies.", "Grognak isn't good at talking, but he knows it has its place. He has friends to talk for him.", "Other barbarians might change their weapons, but Grognak could never leave his beloved axe.")
-	
+
 /obj/item/book/granter/trait/lowsurgery
 	name = "First Aid Pamphlet"
 	desc = "A flimsy collection of vital tips and tricks for the average American with a sudden injury."

--- a/code/modules/clothing/head/f13factionhead.dm
+++ b/code/modules/clothing/head/f13factionhead.dm
@@ -689,8 +689,8 @@
 	flash_protect = 0
 	resistance_flags = null
 	armor = list("tier" = 2, "energy" = 20, "bomb" = 20, "bio" = 20, "rad" = 20, "fire" = 20, "acid" = 0)
-	
-	
+
+
 /obj/item/clothing/head/helmet/f13/rangercombat/eliteriot/reclaimed
 	name = "reclaimed desert ranger gear"
 	desc = "(IV) A refurbished and personalized set of pre-unification desert ranger gear."
@@ -998,12 +998,11 @@
 	item_state = "enclave_cap"
 	armor = list("tier" = 3, "energy" = 20, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 20, "acid" = 0)
 
-/obj/item/clothing/head/helmet/f13/combat/enclave
+/obj/item/clothing/head/helmet/f13/combat/mk2/enclave
 	name = "enclave combat helmet"
 	desc = "(VI) An intimidating helmet that is issued with it's corresponding suit."
 	icon_state = "enclave_new"
 	item_state = "enclave_new"
-	armor = list("tier" = 6, "energy" = 75, "bomb" = 70, "bio" = 80, "rad" = 80, "fire" = 80, "acid" = 50)
 
 /obj/item/clothing/head/helmet/f13/combat/remnant
 	name = "remnant combat helmet"

--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -857,12 +857,11 @@
 
 //Enclave/Remnants
 
-/obj/item/clothing/suit/armor/f13/combat/enclave
+/obj/item/clothing/suit/armor/f13/combat/mk2/enclave
 	name = "enclave combat armor"
 	desc = "(VI) An old set of pre-war combat armor, painted black."
 	icon_state = "enclave_new"
 	item_state = "enclave_new"
-	armor = list("tier" = 6, "energy" = 75, "bomb" = 70, "bio" = 80, "rad" = 80, "fire" = 80, "acid" = 50)
 
 /obj/item/clothing/suit/armor/f13/environmentalsuit
 	name = "enclave envirosuit"

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -24,11 +24,11 @@
 	name = "Enclave Private"
 	jobtype = /datum/job/wasteland/enclavespy
 	backpack = /obj/item/storage/backpack/satchel/leather
-	head = 			/obj/item/clothing/head/helmet/f13/combat/enclave
+	head = 			/obj/item/clothing/head/helmet/f13/combat/mk2/enclave
 	ears = 			/obj/item/radio/headset/headset_enclave
 	glasses = 		/obj/item/clothing/glasses/night
 	uniform =		/obj/item/clothing/under/f13/navy
-	suit = 			/obj/item/clothing/suit/armor/f13/combat/enclave
+	suit = 			/obj/item/clothing/suit/armor/f13/combat/mk2/enclave
 	belt = 			/obj/item/storage/belt/military/army
 	shoes = 		/obj/item/clothing/shoes/combat/swat
 	id = 			/obj/item/card/id/dogtag/enclave
@@ -607,7 +607,9 @@ Raider
 	id = /obj/item/card/id/rusted/brokenholodog/enclave
 	backpack_contents = list(
 		/obj/item/gun/ballistic/automatic/pistol/m1911/compact=1,
-		/obj/item/ammo_box/magazine/m45=2)
+		/obj/item/ammo_box/magazine/m45=2,
+		/obj/item/book/granter/crafting_recipe/enclave_armor,
+		)
 
 
 /datum/job/wasteland/f13wastelander

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -600,6 +600,7 @@ Raider
 
 /datum/outfit/loadout/raider_enclave
 	name = "Enclave Remnant"
+	l_hand = /obj/item/book/granter/crafting_recipe/enclave_armor
 	r_hand = /obj/item/storage/backpack/satchel/enclave
 	suit = /obj/item/clothing/suit/armor/f13/battlecoat/tan/armored // Tier 4 armor
 	uniform = /obj/item/clothing/under/f13/exile/enclave
@@ -608,7 +609,6 @@ Raider
 	backpack_contents = list(
 		/obj/item/gun/ballistic/automatic/pistol/m1911/compact=1,
 		/obj/item/ammo_box/magazine/m45=2,
-		/obj/item/book/granter/crafting_recipe/enclave_armor,
 		)
 
 

--- a/code/modules/mob/living/simple_animal/hostile/f13/fallout_NPC.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/fallout_NPC.dm
@@ -170,7 +170,7 @@
 	gloves = /obj/item/clothing/gloves/f13/military
 	//radio = /obj/item/device/radio/headset
 	mask = /obj/item/clothing/mask/gas
-	head = /obj/item/clothing/head/helmet/f13/combat/enclave
+	head = /obj/item/clothing/head/helmet/f13/combat/mk2/enclave
 	//back = /obj/item/weapon/storage/backpack
 
 /obj/effect/mob_spawn/human/corpse/enclave/soldier


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Enclave Remnant loadout for Outlaws gets a book that teaches some crafting recipes.

Enclave armor requires reinforced combat armor and has the same armor values.

To restore dogtags you need 5 electronic parts, 3 high-quality metal parts, and the "malfunctioning dogtags" you spawn with. These have the ability to set the name and assignment to "Enclave Soldier", but only one use. They also have Enclave access, which is only really useful if you are planning on making some airlocks.

## Why It's Good For The Game

Adds a bit of flavor to this loadout and ability to build proper player bases.

## Changelog
:cl:
add: Enclave remnants(Outlaw loadout) can now craft Enclave combat armor and restored dogtags.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
