### PR TITLE
Display cases don't turn the alarms by default

### DIFF
--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -12,7 +12,7 @@
 	attack_hand_speed = CLICK_CD_MELEE
 	attack_hand_is_action = TRUE
 	var/obj/item/showpiece = null
-	var/alert = TRUE
+	var/alert = FALSE
 	var/open = FALSE
 	var/openable = TRUE
 	var/obj/item/electronics/airlock/electronics


### PR DESCRIPTION
Requested by host
Display cases would turn the light in an area red, and almost no area has air alarms to fix that here