### PR TITLE
Adds wires and signaler support to Universal Recorders

### DIFF
--- a/code/__DEFINES/wires.dm
+++ b/code/__DEFINES/wires.dm
@@ -48,3 +48,7 @@
 #define WIRE_ZAP "High Voltage Circuit"
 #define WIRE_ZAP1 "High Voltage Circuit 1"
 #define WIRE_ZAP2 "High Voltage Circuit 2"
+
+#define WIRE_RECORD "Record"
+#define WIRE_STOP "Stop"
+#define WIRE_PLAY "Play"

--- a/code/datums/wires/taperecorder.dm
+++ b/code/datums/wires/taperecorder.dm
@@ -12,10 +12,10 @@
 	return ..()
 
 /datum/wires/taperecorder/interactable(mob/user)
-	. = FALSE
-	var/obj/item/taperecorder/T = holder
-	if(T.panel_open)
-		. = TRUE
+	var/obj/item/taperecorder/recorder = holder
+	if(recorder.panel_open)
+		return TRUE
+	return FALSE
 
 /datum/wires/taperecorder/on_pulse(wire)
 	var/obj/item/taperecorder/T = holder

--- a/code/datums/wires/taperecorder.dm
+++ b/code/datums/wires/taperecorder.dm
@@ -9,7 +9,7 @@
 		WIRE_RECORD,
 		WIRE_STOP, WIRE_PLAY
 	)
-	..()
+	return ..()
 
 /datum/wires/taperecorder/interactable(mob/user)
 	. = FALSE

--- a/code/datums/wires/taperecorder.dm
+++ b/code/datums/wires/taperecorder.dm
@@ -18,11 +18,11 @@
 	return FALSE
 
 /datum/wires/taperecorder/on_pulse(wire)
-	var/obj/item/taperecorder/T = holder
+	var/obj/item/taperecorder/recorder = holder
 	switch(wire)
 		if(WIRE_RECORD)
-			T.record()
+			recorder.record()
 		if(WIRE_STOP)
-			T.stop()
+			recorder.stop()
 		if(WIRE_PLAY)
-			T.play()
+			recorder.play()

--- a/code/datums/wires/taperecorder.dm
+++ b/code/datums/wires/taperecorder.dm
@@ -26,3 +26,4 @@
 			recorder.stop()
 		if(WIRE_PLAY)
 			recorder.play()
+

--- a/code/datums/wires/taperecorder.dm
+++ b/code/datums/wires/taperecorder.dm
@@ -1,0 +1,28 @@
+/datum/wires/taperecorder
+	holder_type = /obj/item/taperecorder
+	proper_name = "Universal Recorder"
+	req_knowledge = JOB_SKILL_TRAINED
+	req_skill = JOB_SKILL_UNTRAINED
+
+/datum/wires/taperecorder/New(atom/holder)
+	wires = list(
+		WIRE_RECORD,
+		WIRE_STOP, WIRE_PLAY
+	)
+	..()
+
+/datum/wires/taperecorder/interactable(mob/user)
+	. = FALSE
+	var/obj/item/taperecorder/T = holder
+	if(T.panel_open)
+		. = TRUE
+
+/datum/wires/taperecorder/on_pulse(wire)
+	var/obj/item/taperecorder/T = holder
+	switch(wire)
+		if(WIRE_RECORD)
+			T.record()
+		if(WIRE_STOP)
+			T.stop()
+		if(WIRE_PLAY)
+			T.play()

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -41,6 +41,10 @@
 		mytape = I
 		to_chat(user, "<span class='notice'>You insert [I] into [src].</span>")
 		update_icon()
+	else if(is_wire_tool(I) && panel_open)
+		wires.interact(user)
+
+/obj/item/taperecorder/screwdriver_act(mob/living/user, obj/item/I)
 	if(I.tool_behaviour == TOOL_SCREWDRIVER)
 		I.play_tool_sound(src, 50)
 		if(!panel_open)
@@ -49,8 +53,6 @@
 		else
 			panel_open = FALSE
 			to_chat(user, "<span class='notice'>You close the maintenance hatch of [src].</span>")
-	else if(is_wire_tool(I) && panel_open)
-		wires.interact(user)
 
 
 /obj/item/taperecorder/proc/eject(mob/user)

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -45,14 +45,14 @@
 		wires.interact(user)
 
 /obj/item/taperecorder/screwdriver_act(mob/living/user, obj/item/I)
-	if(I.tool_behaviour == TOOL_SCREWDRIVER)
-		I.play_tool_sound(src, 50)
-		if(!panel_open)
-			panel_open = TRUE
-			to_chat(user, "<span class='notice'>You open the maintenance hatch of [src].</span>")
-		else
-			panel_open = FALSE
-			to_chat(user, "<span class='notice'>You close the maintenance hatch of [src].</span>")
+	I.play_tool_sound(src, 50)
+	if(!panel_open)
+		panel_open = TRUE
+		to_chat(user, "<span class='notice'>You open the maintenance hatch of [src].</span>")
+	else
+		panel_open = FALSE
+		to_chat(user, "<span class='notice'>You close the maintenance hatch of [src].</span>")
+	return TRUE
 
 
 /obj/item/taperecorder/proc/eject(mob/user)

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -17,7 +17,7 @@
 	var/playsleepseconds = 0
 	var/obj/item/tape/mytape
 	var/starting_tape_type = /obj/item/tape/random
-	var/open_panel = 0
+	var/panel_open = FALSE
 	var/canprint = 1
 
 
@@ -26,11 +26,12 @@
 	if(starting_tape_type)
 		mytape = new starting_tape_type(src)
 	update_icon()
+	wires = new /datum/wires/taperecorder(src)
 
 
 /obj/item/taperecorder/examine(mob/user)
 	. = ..()
-	. += "The wire panel is [open_panel ? "opened" : "closed"]."
+	. += "The wire panel is [panel_open ? "opened" : "closed"]."
 
 
 /obj/item/taperecorder/attackby(obj/item/I, mob/user, params)
@@ -40,6 +41,16 @@
 		mytape = I
 		to_chat(user, "<span class='notice'>You insert [I] into [src].</span>")
 		update_icon()
+	if(I.tool_behaviour == TOOL_SCREWDRIVER)
+		I.play_tool_sound(src, 50)
+		if(!panel_open)
+			panel_open = TRUE
+			to_chat(user, "<span class='notice'>You open the maintenance hatch of [src].</span>")
+		else
+			panel_open = FALSE
+			to_chat(user, "<span class='notice'>You close the maintenance hatch of [src].</span>")
+	else if(is_wire_tool(I) && panel_open)
+		wires.interact(user)
 
 
 /obj/item/taperecorder/proc/eject(mob/user)

--- a/fortune13.dme
+++ b/fortune13.dme
@@ -714,6 +714,7 @@
 #include "code\datums\wires\robot.dm"
 #include "code\datums\wires\suit_storage_unit.dm"
 #include "code\datums\wires\syndicatebomb.dm"
+#include "code\datums\wires\taperecorder.dm"
 #include "code\datums\wires\tesla_coil.dm"
 #include "code\datums\wires\vending.dm"
 #include "code\datums\wounds\_scars.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
After seeing a reference to an unused wire panel in the description of the Universal Recorder, I decided to go ahead and add wires for the record, stop, and play verb that the taperecorder has. This will allow taperecorders to be controlled via remote signalling devices once attached.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Universal Recorders have always been lacking in my eyes, with hardly anyone (read - no one) using them. With this change, the taperecorders can now be used to construct a varied amount of neat signaller systems, finally giving them a purpose beyond news interviews. Here's a couple of ideas:
- An automated greeting system for stores, houses, or other places via a proximity sensor/infrared emitter and signaller assembly connected to the play button of the recorder
- A warning system that not only tells you when a proximity sensor has been triggered, but by setting a recording, where it has been triggered. (E.g. "Recording playing - "Enemy in the mines!")
- A message recording device for when you are away from home. Set one button on the wall to be the record signaller, and another to be stop, then leave the taperecorder where it can hear but not be touched by visitors.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added wires to Universal Recorders
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
