### PR TITLE
Removing flask, Rebalancing Mutant Village

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -4259,13 +4259,6 @@
 /obj/structure/bed,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
-"dFt" = (
-/mob/living/simple_animal/hostile/supermutant,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker)
 "dFv" = (
 /obj/structure/spacevine{
 	name = "vines"
@@ -5625,14 +5618,6 @@
 	icon_state = "bar"
 	},
 /area/f13/followers)
-"eJH" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/supermutant,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker)
 "eJU" = (
 /obj/effect/decal/fakelattice,
 /obj/machinery/light/small{
@@ -5745,6 +5730,7 @@
 "eOl" = (
 /obj/machinery/autolathe/ammo,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/book/granter/crafting_recipe/gunsmith_four,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -10573,7 +10559,6 @@
 /area/f13/bunker)
 "ivY" = (
 /obj/machinery/light/small/broken,
-/mob/living/simple_animal/hostile/supermutant,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "iwg" = (
@@ -11987,10 +11972,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"jzy" = (
-/mob/living/simple_animal/hostile/supermutant,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "jzC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -23264,10 +23245,6 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/den)
-"rNd" = (
-/mob/living/simple_animal/hostile/supermutant,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/tunnel)
 "rNj" = (
 /obj/structure/table/wood/poker,
 /obj/effect/holodeck_effect/cards,
@@ -24549,10 +24526,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/tunnel)
-"sVv" = (
-/mob/living/simple_animal/hostile/supermutant,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
 "sVL" = (
 /obj/structure/statue/uranium/nuke,
 /obj/machinery/light{
@@ -24941,16 +24914,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/carpet,
 /area/f13/den)
-"tjy" = (
-/obj/structure/table,
-/obj/structure/barricade/bars,
-/obj/item/book/granter/crafting_recipe/gunsmith_four,
-/obj/structure/decoration/rag,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "tjA" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/indestructible/ground/inside/mountain,
@@ -32273,7 +32236,7 @@ vaH
 cgk
 qju
 qju
-tjy
+pQX
 hjf
 fAi
 fLU
@@ -80667,7 +80630,7 @@ nBk
 nBk
 qUv
 nBk
-rNd
+nBk
 nBk
 nBk
 xVt
@@ -81690,7 +81653,7 @@ qUx
 lnr
 lnr
 lnr
-sVv
+lnr
 lnr
 uoO
 nBk
@@ -81945,7 +81908,7 @@ eLE
 uoO
 qUO
 lnr
-sVv
+lnr
 lnr
 lnr
 lnr
@@ -82208,7 +82171,7 @@ lnr
 lnr
 uoO
 nBk
-rNd
+nBk
 nBk
 uoO
 uoO
@@ -84510,10 +84473,10 @@ uoO
 fLU
 gmN
 oPR
-eJH
+dbx
 pHq
 dbx
-eJH
+dbx
 smm
 qIH
 fLU
@@ -85281,7 +85244,7 @@ uoO
 fLU
 oVe
 dbx
-dFt
+oPR
 hQE
 uoO
 uoO
@@ -86570,7 +86533,7 @@ eLE
 uoO
 xyk
 rrZ
-jzy
+rrZ
 rrZ
 rrZ
 xyk

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -673,7 +673,7 @@ Raider
 	ears = null
 	belt = null
 	r_hand = /obj/item/book/granter/trait/selection
-	l_pocket = /obj/item/reagent_containers/food/drinks/flask
+	l_pocket = /obj/item/storage/bag/money/small/wastelander
 	r_pocket = /obj/item/flashlight/flare
 	belt = /obj/item/melee/onehanded/knife/survival
 	backpack = /obj/item/storage/backpack/satchel/explorer
@@ -682,7 +682,6 @@ Raider
 		/obj/item/reagent_containers/hypospray/medipen/stimpak,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak,
 		/obj/item/reagent_containers/pill/radx,
-		/obj/item/storage/bag/money/small/wastelander,
 		)
 
 /datum/outfit/job/wasteland/f13wastelander/pre_equip(mob/living/carbon/human/H)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removing the flask from wastelander spawn and putting the money purse where it would spawn in the pocket, a little easier for wastelanders who have to shift around all their belongings at the start of the round and removing the flask since its just clutter. Also moved the super mutants back to their original numbers in the village I made because it is meant to be twelve mutants, twelve beds. Spamming vault mutants and melee mutants around the place has no sense to it, so I undid that.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixed my original part of the map and tweaked wastelander slightly for balance.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: rebalanced the amount of mutants from the mutant village, removed the flask from the wastelander spawn
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
