### PR TITLE
Bugfix no 575

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -73,7 +73,7 @@ SUBSYSTEM_DEF(shuttle)
 		if(!P.contains)
 			continue
 		supply_packs[P.type] = P
-/* Warnings for lacking docking points disabled for now. Causes error message each time the server loads, annoying.
+// Warnings for lacking docking points can't be commented out without causing linter stop. Obsolete ?
 	initial_load()
 
 	if(!arrivals)
@@ -86,7 +86,6 @@ SUBSYSTEM_DEF(shuttle)
 		WARNING("No /obj/docking_port/mobile/supply placed on the map!")
 		realtimeofstart = world.realtime
 	return ..()
-*/
 
 /datum/controller/subsystem/shuttle/proc/initial_load()
 	for(var/s in stationary)

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -73,7 +73,7 @@ SUBSYSTEM_DEF(shuttle)
 		if(!P.contains)
 			continue
 		supply_packs[P.type] = P
-
+/* Warnings for lacking docking points disabled for now. Causes error message each time the server loads, annoying.
 	initial_load()
 
 	if(!arrivals)
@@ -86,6 +86,7 @@ SUBSYSTEM_DEF(shuttle)
 		WARNING("No /obj/docking_port/mobile/supply placed on the map!")
 		realtimeofstart = world.realtime
 	return ..()
+*/
 
 /datum/controller/subsystem/shuttle/proc/initial_load()
 	for(var/s in stationary)

--- a/code/datums/components/crafting/recipes/recipes_primal.dm
+++ b/code/datums/components/crafting/recipes/recipes_primal.dm
@@ -245,7 +245,7 @@
 	result = /obj/item/ammo_casing/caseless/arrow/poison
 	time = 30
 	reqs = list(/obj/item/ammo_casing/caseless/arrow = 1,
-				/obj/item/grown/nettle/basic = 5)
+				/obj/item/reagent_containers/food/snacks/grown/nettle = 5)
 	category = CAT_TRIBAL
 	tools = list(TOOL_WORKBENCH)
 

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -96,7 +96,7 @@
 		I = icon('icons/obj/stationobjs.dmi',"glassboxb0")
 	if(showpiece)
 		var/icon/S = getFlatIcon(showpiece)
-		S.Scale(17,17)
+		S.Scale(17,17)	// Runtime. Cannot execute null.Scale() .  Obsolete ?
 		I.Blend(S,ICON_UNDERLAY,8,8)
 	src.icon = I
 	return

--- a/code/modules/asset_cache/asset_list.dm
+++ b/code/modules/asset_cache/asset_list.dm
@@ -175,7 +175,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 
 /datum/asset/spritesheet/proc/Insert(sprite_name, icon/I, icon_state="", dir=SOUTH, frame=1, moving=FALSE)
 	I = icon(I, icon_state=icon_state, dir=dir, frame=frame, moving=moving)
-	if (!I || !length(icon_states(I)))  // that direction or state doesn't exist
+	if (!I || !length(icon_states(I)))  // that direction or state doesn't exist // Bad Icon runtime on this line. Obsolete ?
 		return
 	//any sprite modifications we want to do (aka, coloring a greyscaled asset)
 	I = ModifyInserted(I)
@@ -211,7 +211,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 	if (!directions)
 		directions = list(SOUTH)
 
-	for (var/icon_state_name in icon_states(I))
+	for (var/icon_state_name in icon_states(I)) // Bad Icon runtime on this line. Obsolete ?
 		for (var/direction in directions)
 			var/prefix2 = (directions.len > 1) ? "[dir2text(direction)]-" : ""
 			Insert("[prefix][prefix2][icon_state_name]", I, icon_state=icon_state_name, dir=direction)

--- a/code/modules/asset_cache/asset_list_items.dm
+++ b/code/modules/asset_cache/asset_list_items.dm
@@ -359,7 +359,7 @@
 		var/icon_file = initial(item.icon)
 		var/icon_state = initial(item.icon_state)
 		var/icon/I
-		var/icon_states_list = icon_states(icon_file)
+		var/icon_states_list = icon_states(icon_file) // Bad Icon runtime on this line. Obsolete ?
 		if(icon_state in icon_states_list)
 			I = icon(icon_file, icon_state, SOUTH)
 			var/c = initial(item.color)
@@ -442,7 +442,7 @@
 			var/obj/machinery/computer/C = item
 			var/screen = initial(C.icon_screen)
 			var/keyboard = initial(C.icon_keyboard)
-			var/all_states = icon_states(icon_file)
+			var/all_states = icon_states(icon_file) // Bad Icon runtime on this line. Obsolete ?
 			if (screen && (screen in all_states))
 				I.Blend(icon(icon_file, screen, SOUTH), ICON_OVERLAY)
 			if (keyboard && (keyboard in all_states))
@@ -474,7 +474,7 @@
 					world.log << "MISSING ICON FOR [initial(I.name)] IN [O.type] OF [j]"
 					continue
 				var/icon_state = initial(I.icon_state)
-				if(isnull(icon_state) || !(icon_state in icon_states(icon_file)))
+				if(isnull(icon_state) || !(icon_state in icon_states(icon_file))) // Bad Icon runtime on this line. Obsolete ?
 					world.log << "MISSING ICON STATE[isnull(icon_state) ? null : " "][icon_state] FOR [itemtype]"
 					continue
 				var/c = initial(I.color)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -791,7 +791,7 @@ ATTACHMENTS
 	. = ..()
 	if(gun_light)
 		var/state = "[gunlight_state][gun_light.on? "_on":""]"	//Generic state.
-		if(gun_light.icon_state in icon_states('icons/fallout/objects/guns/attachments.dmi'))	//Snowflake state?
+		if(gun_light.icon_state in icon_states('icons/fallout/objects/guns/attachments.dmi'))	//Snowflake state? Obsolete ?
 			state = gun_light.icon_state
 		flashlight_overlay = mutable_appearance('icons/fallout/objects/guns/attachments.dmi', state)
 		flashlight_overlay.pixel_x = flight_x_offset
@@ -801,7 +801,7 @@ ATTACHMENTS
 		flashlight_overlay = null
 
 	if(bayonet)
-		if(bayonet.icon_state in icon_states('icons/fallout/objects/guns/attachments.dmi'))		//Snowflake state?
+		if(bayonet.icon_state in icon_states('icons/fallout/objects/guns/attachments.dmi'))		//Snowflake state? Obsolete ?
 			knife_overlay = bayonet.icon_state
 		var/icon/bayonet_icons = 'icons/fallout/objects/guns/attachments.dmi'
 		knife_overlay = mutable_appearance(bayonet_icons, bayonet_state)

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -52,11 +52,6 @@
 	use_cyborg_cell = TRUE
 	selfcharge = EGUN_NO_SELFCHARGE
 
-/obj/item/gun/energy/laser/scatter
-	name = "scatter laser gun"
-	desc = "A laser gun equipped with a refraction kit that spreads bolts."
-	ammo_type = list(/obj/item/ammo_casing/energy/laser/scatter, /obj/item/ammo_casing/energy/laser)
-
 //Laser Cannon
 /obj/item/gun/energy/lasercannon
 	name = "accelerator laser cannon"


### PR DESCRIPTION
## About The Pull Request

Tried chipping away at the runtimes, could only fix the scatter laser one (tribeam has had the same path as a legacy gun all this time, no more) and the warning for shuttle console lacking (commented out)
Marked some runtimes I could not understand how to fix with "Obsolete ?"  so try searching for that in VSC if you are in the mood to try to fix them.

Several people reported poison arrows not working, tribals is not my area but its annoying to have a bug like that so tried to fix it by replacing the faulty ingridient path with this one wich seems to be the one needed.
/obj/item/reagent_containers/food/snacks/grown/nettle
Should fix it, worst case scenario it breaks nothing and the arrow is still uncraftable. 