### PR TITLE
Returns honking to horns... at a cost

### DIFF
--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -10,12 +10,12 @@
 
 	// This is to stop squeak spam from inhand usage
 	var/last_use = 0
-	var/use_delay = 20
-	
+	var/use_delay = 50
+
 	// squeak cooldowns
 	var/last_squeak = 0
-	var/squeak_delay = 5
-	
+	var/squeak_delay = 50
+
 	/// chance we'll be stopped from squeaking by cooldown when something crossing us squeaks
 	var/cross_squeak_delay_chance = 33		// about 3 things can squeak at a time
 

--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -119,6 +119,10 @@
 	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, moodlet, /datum/mood_event/honk)
 	return ..()
 
+/obj/item/bikehorn/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/squeak, honksounds, 50)
+
 /obj/item/bikehorn/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] solemnly points the horn at [user.p_their()] temple! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	playsound(src, pickweight(honksounds), 50, 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Returns the squeak component to the bike horn object. Changes the global squeak delay and use delay, reducing the spammable ability of all items containing the squeak component.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bike horns, along with a few other items, had their squeak components removed due to the fact that their spammable sounds were considered LRP. Instead of removing every single squeak component from every single plushie or other such item, I've decided to just adjust the global delay value, thus decreasing (presumably) the potential for spammy, low RP shenanigans. This also still preserves the object's original noise, allowing you to hug and d'aww at the cute plushie noises or punctuate a joke with a honk, if you wish to RP as a horrible comedian (ba-dum tsh drum not included). 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Re-added the squeak component to bike horns
tweak: Tweaked the squeak_delay and use_delay value
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
