### PR TITLE
nerfbat to the top ammo types

### DIFF
--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -10,10 +10,10 @@
 /obj/item/ammo_box/shotgun
 	icon = 'icons/fallout/objects/guns/ammo.dmi'
 	max_ammo = 12
-	custom_materials = list(/datum/material/iron = 6000, /datum/material/blackpowder = 1500)
 	ammo_type = /obj/item/ammo_casing/shotgun
 	multiple_sprites = 1
-	
+	custom_materials = list(/datum/material/iron = 4000, /datum/material/blackpowder = 1000)
+
 /obj/item/ammo_box/shotgun/slug
 	name = "Slug shotgun ammo box"
 	desc = "A box full of shotgun shells."
@@ -63,17 +63,15 @@
 	ammo_type = /obj/item/ammo_casing/a22
 	max_ammo = 40
 	w_class = WEIGHT_CLASS_SMALL
-	custom_materials = list(/datum/material/iron = 6000, /datum/material/blackpowder = 1500)
+	custom_materials = list(/datum/material/iron = 4000, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/m22/plinking
 	name = "ammo box (.22lr plinking)"
 	ammo_type = /obj/item/ammo_casing/a22/plinking
-	custom_materials = list(/datum/material/iron = 3000, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/m22/hp
 	name = "ammo box (.22lr hollow point)"
 	ammo_type = /obj/item/ammo_casing/a22/hp
-	custom_materials = list(/datum/material/iron = 8000, /datum/material/blackpowder = 2000)
 
 
 //9mm and .38
@@ -85,22 +83,20 @@
 	caliber = "9mm"
 	ammo_type = /obj/item/ammo_casing/c9mm
 	max_ammo = 30
-	custom_materials = list(/datum/material/iron = 15000, /datum/material/blackpowder = 1500)
+	custom_materials = list(/datum/material/iron = 4000, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/c9mm/ap
 	name = "ammo box (9mm AP)"
 	ammo_type = /obj/item/ammo_casing/c9mm/ap
-	custom_materials = list(/datum/material/iron = 15000, /datum/material/titanium = 3750, /datum/material/blackpowder = 2000)
+	custom_materials = list(/datum/material/iron = 4000, /datum/material/titanium = 500, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/c9mm/jhp
 	name = "ammo box (9mm JHP)"
 	ammo_type = /obj/item/ammo_casing/c9mm/jhp
-	custom_materials = list(/datum/material/iron = 11000, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/c9mm/op
 	name = "ammo box (9mm +P)"
 	ammo_type = /obj/item/ammo_casing/c9mm/op
-	custom_materials = list(/datum/material/iron = 19000, /datum/material/blackpowder = 3500)
 
 /obj/item/ammo_box/c38box
 	name = "ammo box (.38)"
@@ -110,7 +106,7 @@
 	caliber = "38"
 	ammo_type = /obj/item/ammo_casing/c38
 	max_ammo = 30
-	custom_materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1000)
+	custom_materials = list(/datum/material/iron = 4000, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/c38box/improvised
 	name = "bag with reloaded .38 bullets"
@@ -130,12 +126,11 @@
 	ammo_type = /obj/item/ammo_casing/c10mm
 	caliber = "10mm"
 	max_ammo = 30
-	custom_materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1000)
+	custom_materials = list(/datum/material/iron = 4000, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/c10mm/jhp
 	name = "ammo box (10mm JHP)"
 	ammo_type = /obj/item/ammo_casing/c10mm/jhp
-	custom_materials = list(/datum/material/iron = 6000, /datum/material/blackpowder = 1500)
 
 /obj/item/ammo_box/c10mm/fire
 	name = "ammo box (10mm Incendiary)"
@@ -145,7 +140,7 @@
 /obj/item/ammo_box/c10mm/ap
 	name = "ammo box (10mm AP)"
 	ammo_type = /obj/item/ammo_casing/c10mm/ap
-	custom_materials = list(/datum/material/iron = 14000, /datum/material/titanium = 3500, /datum/material/blackpowder = 1500)
+	custom_materials = list(/datum/material/iron = 4000, /datum/material/titanium = 500, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/c10mm/improvised
 	name = "bag with reloaded 10mm bullets"
@@ -161,21 +156,20 @@
 	icon = 'icons/fallout/objects/guns/ammo.dmi'
 	icon_state = "357box"
 	multiple_sprites = 2
+	w_class = WEIGHT_CLASS_NORMAL
 	caliber = "357"
 	ammo_type = /obj/item/ammo_casing/a357
 	max_ammo = 30
-	custom_materials = list(/datum/material/iron = 16000, /datum/material/blackpowder = 1500)
-	w_class = WEIGHT_CLASS_NORMAL
+	custom_materials = list(/datum/material/iron = 4000, /datum/material/blackpowder = 1000)
+
 
 /obj/item/ammo_box/a357box/jhp
 	name = "ammo box (.357 Magnum JHP)"
 	ammo_type = /obj/item/ammo_casing/a357/jhp
-	custom_materials = list(/datum/material/iron = 12000, /datum/material/blackpowder = 1500)
 
 /obj/item/ammo_box/a357box/jfp
 	name = "ammo box (.357 Magnum JFP)"
 	ammo_type = /obj/item/ammo_casing/a357/jfp
-	custom_materials = list(/datum/material/iron = 19000, /datum/material/blackpowder = 2000)
 
 
 //.44 Magnum
@@ -188,17 +182,15 @@
 	ammo_type = /obj/item/ammo_casing/m44
 	max_ammo = 30
 	w_class = WEIGHT_CLASS_NORMAL
-	custom_materials = list(/datum/material/iron = 14000, /datum/material/blackpowder = 1500)
+	custom_materials = list(/datum/material/iron = 4000, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/m44box/jhp
 	name = "ammo box (.44 Magnum JHP)"
 	ammo_type = /obj/item/ammo_casing/m44/jhp
-	custom_materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1500)
 
 /obj/item/ammo_box/m44box/swc
 	name = "ammo box (.44 Magnum SWC)"
 	ammo_type = /obj/item/ammo_casing/m44/swc
-	custom_materials = list(/datum/material/iron = 19000, /datum/material/blackpowder = 2000)
 
 /obj/item/ammo_box/a45lcbox
 	name = "ammo box (.45 Long Colt)"
@@ -208,7 +200,7 @@
 	ammo_type = /obj/item/ammo_casing/a45lc
 	max_ammo = 30
 	w_class = WEIGHT_CLASS_NORMAL
-	custom_materials = list(/datum/material/iron = 14000, /datum/material/blackpowder = 1500)
+	custom_materials = list(/datum/material/iron = 4000, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/m44box/improvised
 	name = "bag with reloaded .44 bullets"
@@ -228,17 +220,15 @@
 	icon_state = "45box"
 	ammo_type = /obj/item/ammo_casing/c45
 	max_ammo = 30
-	custom_materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1500)
+	custom_materials = list(/datum/material/iron = 4000, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/c45/jhp
 	name = "ammo box (.45 JHP)"
 	ammo_type = /obj/item/ammo_casing/c45/jhp
-	custom_materials = list(/datum/material/iron = 6000, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/c45/op
 	name = "ammo box (.45 +P)"
 	ammo_type = /obj/item/ammo_casing/c45/op
-	custom_materials = list(/datum/material/iron = 14000, /datum/material/blackpowder = 2000)
 
 /obj/item/ammo_box/c45/improvised
 	name = "bag with reloaded .45 ACP bullets"
@@ -259,17 +249,15 @@
 	ammo_type = /obj/item/ammo_casing/c4570
 	max_ammo = 30
 	w_class = WEIGHT_CLASS_NORMAL
-	custom_materials = list(/datum/material/iron = 16000, /datum/material/blackpowder = 2000)
+	custom_materials = list(/datum/material/iron = 4000, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/c4570box/jhp
 	name = "ammo box (.45-70 JHP)"
 	ammo_type = /obj/item/ammo_casing/c4570/jhp
-	custom_materials = list(/datum/material/iron = 12000, /datum/material/blackpowder = 2000)
 
 /obj/item/ammo_box/c4570box/swc
 	name = "ammo box (.45-70 SWC)"
 	ammo_type = /obj/item/ammo_casing/c4570/swc
-	custom_materials = list(/datum/material/iron = 20000, /datum/material/blackpowder = 3500)
 
 
 //5.56x45
@@ -282,27 +270,24 @@
 	ammo_type = /obj/item/ammo_casing/a556
 	max_ammo = 40
 	w_class = WEIGHT_CLASS_NORMAL
-	custom_materials = list(/datum/material/iron = 20000, /datum/material/blackpowder = 1500)
+	custom_materials = list(/datum/material/iron = 4000, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/a556/jhp
 	name = "ammo box (5.56 JHP)"
 	ammo_type = /obj/item/ammo_casing/a556/jhp
-	custom_materials = list(/datum/material/iron = 16000, /datum/material/blackpowder = 1500)
 
 /obj/item/ammo_box/a556/ap
 	name = "ammo box (5.56 AP)"
 	ammo_type = /obj/item/ammo_casing/a556/ap
-	custom_materials = list(/datum/material/iron = 24000, /datum/material/titanium = 6000, /datum/material/blackpowder = 1500)
+	custom_materials = list(/datum/material/iron = 4000, /datum/material/titanium = 500, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/a556/match
 	name = "ammo box (5.56 match)"
 	ammo_type = /obj/item/ammo_casing/a556/match
-	custom_materials = list(/datum/material/iron = 28000, /datum/material/blackpowder = 3500)
 
 /obj/item/ammo_box/a556/sport
 	name = "ammo box (.223 sport)"
 	ammo_type = /obj/item/ammo_casing/a556/sport
-	custom_materials = list(/datum/material/iron = 16000, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/a556/sport/improvised
 	name = "bag with reloaded .223 bullets"
@@ -323,7 +308,7 @@
 	ammo_type = /obj/item/ammo_casing/a762/sport
 	max_ammo = 30
 	w_class = WEIGHT_CLASS_NORMAL
-	custom_materials = list(/datum/material/iron = 14000, /datum/material/blackpowder = 1000)
+	custom_materials = list(/datum/material/iron = 4000, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/a762box
 	name = "ammo box (7.62x51 FMJ)"
@@ -334,22 +319,20 @@
 	ammo_type = /obj/item/ammo_casing/a762
 	max_ammo = 30
 	w_class = WEIGHT_CLASS_NORMAL
-	custom_materials = list(/datum/material/iron = 16000, /datum/material/blackpowder = 1500)
+	custom_materials = list(/datum/material/iron = 4000, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/a762box/jhp
 	name = "ammo box (7.62x51 JHP)"
 	ammo_type = /obj/item/ammo_casing/a762/jhp
-	custom_materials = list(/datum/material/iron = 12000, /datum/material/blackpowder = 1500)
 
 /obj/item/ammo_box/a762box/ap
 	name = "ammo box (7.62x51 AP)"
 	ammo_type = /obj/item/ammo_casing/a762/ap
-	custom_materials = list(/datum/material/iron = 20000, /datum/material/titanium = 5000, /datum/material/blackpowder = 2000)
+	custom_materials = list(/datum/material/iron = 4000, /datum/material/titanium = 500, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/a762box/match
 	name = "ammo box (7.62x51 Match)"
 	ammo_type = /obj/item/ammo_casing/a762/match
-	custom_materials = list(/datum/material/iron = 28000, /datum/material/blackpowder = 3500)
 
 
 //.50 MG and 14mm
@@ -362,7 +345,7 @@
 	ammo_type = /obj/item/ammo_casing/a50MG
 	max_ammo = 25
 	w_class = WEIGHT_CLASS_NORMAL
-	custom_materials = list(/datum/material/iron = 20000, /datum/material/blackpowder = 2000)
+	custom_materials = list(/datum/material/iron = 4000, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/m14mm
 	name = "ammo box (14mm)"
@@ -373,12 +356,11 @@
 	ammo_type = /obj/item/ammo_casing/p14mm
 	max_ammo = 30
 	w_class = WEIGHT_CLASS_NORMAL
-	custom_materials = list(/datum/material/iron = 11000, /datum/material/blackpowder = 1500)
+	custom_materials = list(/datum/material/iron = 4000, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/m14mm/jhp
 	name = "ammo box (14mm JHP)"
 	ammo_type = /obj/item/ammo_casing/p14mm/jhp
-	custom_materials = list(/datum/material/iron = 11000)
 
 
 //Misc.
@@ -425,7 +407,7 @@
 
 /obj/item/ammo_box/tube
 	icon = 'icons/fallout/objects/guns/ammo.dmi'
-	custom_materials = list(/datum/material/iron = 6000)
+	custom_materials = list(/datum/material/iron = 4000)
 	multiple_sprites = 1
 
 //.38
@@ -437,7 +419,7 @@
 	ammo_type = /obj/item/ammo_casing/c38
 	max_ammo = 6
 	multiple_sprites = 1
-	custom_materials = list(/datum/material/iron = 3000)
+	custom_materials = list(/datum/material/iron = 2000)
 
 /obj/item/ammo_box/c38/empty
 	start_empty = 1
@@ -452,7 +434,7 @@
 	ammo_type = /obj/item/ammo_casing/c10mm
 	max_ammo = 12
 	multiple_sprites = 1
-	custom_materials = list(/datum/material/iron = 3000)
+	custom_materials = list(/datum/material/iron = 2000)
 
 /obj/item/ammo_box/l10mm/empty
 	start_empty = 1
@@ -467,7 +449,7 @@
 	caliber = "357"
 	max_ammo = 6
 	multiple_sprites = 1
-	custom_materials = list(/datum/material/iron = 3000)
+	custom_materials = list(/datum/material/iron = 2000)
 
 /obj/item/ammo_box/a357/match
 	name = "speed loader (.357 Match)"
@@ -501,7 +483,7 @@
 	max_ammo = 6
 	caliber = "44"
 	multiple_sprites = 1
-	custom_materials = list(/datum/material/iron = 3000)
+	custom_materials = list(/datum/material/iron =2000)
 
 /obj/item/ammo_box/m44/empty
 	start_empty = 1
@@ -528,7 +510,7 @@
 	ammo_type = /obj/item/ammo_casing/c45
 	max_ammo = 7
 	multiple_sprites = 1
-	custom_materials = list(/datum/material/iron = 3000)
+	custom_materials = list(/datum/material/iron = 2000)
 
 /obj/item/ammo_box/c45rev/empty
 	start_empty = 1
@@ -541,7 +523,7 @@
 	ammo_type = /obj/item/ammo_casing/a45lc
 	max_ammo = 6
 	multiple_sprites = 1
-	custom_materials = list(/datum/material/iron = 3000)
+	custom_materials = list(/datum/material/iron = 2000)
 
 /obj/item/ammo_box/a45lcrev/empty
 	start_empty = 1
@@ -556,7 +538,7 @@
 	ammo_type = /obj/item/ammo_casing/c4570
 	max_ammo = 6
 	multiple_sprites = 1
-	custom_materials = list(/datum/material/iron = 3000)
+	custom_materials = list(/datum/material/iron = 2000)
 
 /obj/item/ammo_box/c4570/empty
 	start_empty = 1
@@ -633,7 +615,7 @@
 	ammo_type = /obj/item/ammo_casing/a762
 	max_ammo = 5
 	multiple_sprites = 1
-	custom_materials = list(/datum/material/iron = 3000)
+	custom_materials = list(/datum/material/iron = 2000)
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/ammo_box/a308
@@ -644,7 +626,7 @@
 	ammo_type = /obj/item/ammo_casing/a762/sport
 	max_ammo = 5
 	multiple_sprites = 1
-	custom_materials = list(/datum/material/iron = 3000)
+	custom_materials = list(/datum/material/iron = 2000)
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/ammo_box/a762/doublestacked
@@ -655,7 +637,7 @@
 	ammo_type = /obj/item/ammo_casing/a762/sport
 	max_ammo = 10
 	multiple_sprites = 1
-	custom_materials = list(/datum/material/iron = 3000)
+	custom_materials = list(/datum/material/iron = 2000)
 	w_class = WEIGHT_CLASS_SMALL
 
 //5.56x45mm
@@ -666,7 +648,7 @@
 	ammo_type = /obj/item/ammo_casing/a556
 	max_ammo = 5
 	multiple_sprites = 1
-	custom_materials = list(/datum/material/iron = 3000)
+	custom_materials = list(/datum/material/iron = 2000)
 	w_class = WEIGHT_CLASS_SMALL
 
 
@@ -716,7 +698,7 @@
 	ammo_type = /obj/item/ammo_casing/a50MG/incendiary
 	max_ammo = 5
 	multiple_sprites = 1
-	custom_materials = list(/datum/material/iron = 20000)
+	custom_materials = list(/datum/material/iron = 3000)
 
 
 /obj/item/ammo_box/a50MG/explosive
@@ -726,7 +708,7 @@
 	ammo_type = /obj/item/ammo_casing/a50MG/explosive
 	max_ammo = 5
 	multiple_sprites = 1
-	custom_materials = list(/datum/material/iron = 20000)
+	custom_materials = list(/datum/material/iron = 3000)
 
 
 ////////////////////////////////

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -38,8 +38,8 @@
 			auto_sear = A
 			src.desc += " It has an automatic sear installed."
 			src.burst_size += 1
-			src.spread += 6
-			src.recoil += 0.1
+			src.spread += 10
+			src.recoil += 0.3
 			src.automatic_burst_overlay = TRUE
 			src.semi_auto = FALSE
 			to_chat(user, "<span class='notice'>You attach \the [A] to \the [src].</span>")

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -89,16 +89,6 @@
 	. = ..()
 	safe_calibers = magazine.caliber
 
-/obj/item/gun/ballistic/revolver/detective/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0, stam_cost = 0)
-	if(chambered && !(chambered.caliber in safe_calibers))
-		if(prob(70 - (magazine.ammo_count() * 10)))	//minimum probability of 10, maximum of 60
-			playsound(user, fire_sound, 50, 1)
-			to_chat(user, "<span class='userdanger'>[src] blows up in your face!</span>")
-			user.take_bodypart_damage(0,20)
-			user.dropItemToGround(src)
-			return FALSE
-	..()
-
 /obj/item/gun/ballistic/revolver/detective/screwdriver_act(mob/living/user, obj/item/I)
 	if(..())
 		return TRUE

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -269,7 +269,7 @@
 	name = "plasma bolt"
 	icon_state = "plasma_clot"
 	damage_type = BURN
-	damage = 49
+	damage = 46
 	armour_penetration = 0.6
 	flag = "laser"
 	eyeblur = 0
@@ -337,7 +337,7 @@
 	name = "plasma bolt"
 	icon_state = "plasma_clot"
 	damage_type = BURN
-	damage = 46
+	damage = 44
 	armour_penetration = 0.5
 	flag = "laser" //checks vs. energy protection
 	eyeblur = 0
@@ -366,21 +366,21 @@
 	is_reflectable = FALSE
 
 /obj/item/projectile/f13plasma/pistol //Plasma pistol
-	damage = 42
+	damage = 41
 	armour_penetration = 0.35
 
 /obj/item/projectile/f13plasma/pistol/glock //Glock (streamlined plasma pistol)
-	damage = 38
+	damage = 37
 	armour_penetration = 0.5
 
 /obj/item/projectile/f13plasma/scatter //Multiplas, fires 3 shots, will melt you
-	damage = 24
+	damage = 23
 	armour_penetration = 0.35
 
 /obj/item/projectile/beam/laser/rcw //RCW
 	name = "rapidfire beam"
 	icon_state = "xray"
-	damage = 40
+	damage = 38
 	armour_penetration = 0.25
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 	light_color = LIGHT_COLOR_GREEN
@@ -394,14 +394,14 @@
 /obj/item/projectile/beam/laser/laer //Elder's/Unique LAER
 	name = "advanced laser beam"
 	icon_state = "u_laser"
-	damage = 45
+	damage = 43
 	armour_penetration = 0.8
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_BLUE
 
 /obj/item/projectile/beam/laser/aer14 //AER14
 	name = "laser beam"
-	damage = 38
+	damage = 37
 	armour_penetration = 0.6
 	icon_state = "omnilaser"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
@@ -422,5 +422,5 @@
 
 /obj/item/projectile/beam/laser/musket //musket
 	name = "laser bolt"
-	damage = 40
-	armour_penetration = 0.6
+	damage = 35
+	armour_penetration = 0.5

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -53,7 +53,7 @@ Civilian round				=	-10% damage. AP reduced by 50%
 
 //////////
 // 9 MM //
-//////////				-Light round, allround
+//////////			-Light round, allround
 
 /obj/item/projectile/bullet/c9mm
 	name = "9mm FMJ bullet"
@@ -87,7 +87,7 @@ Civilian round				=	-10% damage. AP reduced by 50%
 
 ///////////
 // 10 MM //
-///////////				-Medium round, AP focus
+///////////			-Medium round, AP focus
 
 /obj/item/projectile/bullet/c10mm
 	name = "10mm FMJ bullet"
@@ -112,7 +112,7 @@ Civilian round				=	-10% damage. AP reduced by 50%
 
 /////////////
 // .45 ACP //
-/////////////			-Medium round, damage focus
+/////////////		-Medium round, damage focus
 
 /obj/item/projectile/bullet/c45
 	name = ".45 FMJ bullet"
@@ -140,7 +140,7 @@ Civilian round				=	-10% damage. AP reduced by 50%
 
 /obj/item/projectile/bullet/a357
 	name = ".357 FMJ bullet"
-	damage = 36
+	damage = 34
 	armour_penetration = 0.15
 	wound_bonus = 14
 	bare_wound_bonus = -14
@@ -166,8 +166,8 @@ Civilian round				=	-10% damage. AP reduced by 50%
 
 /obj/item/projectile/bullet/m44
 	name = ".44 FMJ bullet"
-	damage = 38
-	armour_penetration = 0.2
+	damage = 36
+	armour_penetration = 0.15
 	wound_bonus = 20
 	bare_wound_bonus = -20
 
@@ -192,26 +192,26 @@ Civilian round				=	-10% damage. AP reduced by 50%
 
 ////////////
 // .45-70 //
-////////////			-Heavy round, AP focus
+////////////		-Heavy round, AP focus
 
 /obj/item/projectile/bullet/c4570
 	name = ".45-70 FMJ bullet"
-	damage = 42
-	armour_penetration = 0.3
-	wound_bonus = 24
-	bare_wound_bonus = -24
+	damage = 38
+	armour_penetration = 0.2
+	wound_bonus = 20
+	bare_wound_bonus = -20
 
 /obj/item/projectile/bullet/c4570/jhp
 	name = ".45-70 JHP bullet"
 	damage = 49
-	armour_penetration = 0.1
+	armour_penetration = 0
 	wound_bonus = -36
 	bare_wound_bonus = 36
 
 /obj/item/projectile/bullet/c4570/swc
 	name = ".45-70 SWC bullet"
 	damage = 42
-	armour_penetration = 0.2
+	armour_penetration = 0.1
 	wound_bonus = 36
 	bare_wound_bonus = 36
 
@@ -228,21 +228,21 @@ Civilian round				=	-10% damage. AP reduced by 50%
 
 ///////////
 // 14 MM //
-///////////				-Heavy round, damage focus
+///////////			-Heavy round, damage focus
 
 /obj/item/projectile/bullet/mm14
 	name = "14mm FMJ bullet"
-	damage = 44
-	armour_penetration = 0.2
+	damage = 42
+	armour_penetration = 0.1
 	wound_bonus = 28
 	bare_wound_bonus = -28
 
 /obj/item/projectile/bullet/mm14/jhp
 	name = "14mm JHP bullet"
-	damage = 54
+	damage = 52
 	armour_penetration = 0
-	wound_bonus = -42
-	bare_wound_bonus = 42
+	wound_bonus = -36
+	bare_wound_bonus = 36
 
 
 //////////////////////
@@ -266,7 +266,7 @@ Civilian round				=	-10% damage. AP reduced by 50%
 
 /////////////
 // NEEDLER //
-/////////////			- AP focus
+/////////////		- AP focus
 
 /obj/item/projectile/bullet/needle
 	name = "needle"

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -22,17 +22,17 @@ Civilian round				=	-10% damage for .223. AP reduced by 50%
 
 /obj/item/projectile/bullet/a556
 	name = "5.56 FMJ bullet"
-	damage = 33
-	armour_penetration = 0.2
-	wound_bonus = 18
-	bare_wound_bonus = -18
+	damage = 31
+	armour_penetration = 0.1
+	wound_bonus = 15
+	bare_wound_bonus = -15
 
 /obj/item/projectile/bullet/a556/ap
 	name = "5.56 AP bullet"
-	damage = 26
-	armour_penetration = 0.4
-	wound_bonus = 9
-	bare_wound_bonus = -9
+	damage = 24
+	armour_penetration = 0.3
+	wound_bonus = 8
+	bare_wound_bonus = -8
 
 /obj/item/projectile/bullet/a556/jhp
 	name = "5.56 JHP bullet"
@@ -44,7 +44,7 @@ Civilian round				=	-10% damage for .223. AP reduced by 50%
 /obj/item/projectile/bullet/a556/match
 	name = "5.56 match bullet"
 	damage = 33
-	armour_penetration = 0.22
+	armour_penetration = 0.12
 	wound_bonus = 16
 	bare_wound_bonus = -16
 	var/extra_speed = 200
@@ -53,8 +53,8 @@ Civilian round				=	-10% damage for .223. AP reduced by 50%
 	name = ".223 FMJ bullet"
 	damage = 30
 	armour_penetration = 0.1
-	wound_bonus = 18
-	bare_wound_bonus = -18
+	wound_bonus = 12
+	bare_wound_bonus = -12
 
 /obj/item/projectile/bullet/a556/simple //for simple mobs, separate to allow balancing
 	name = "5.56 bullet"
@@ -69,15 +69,15 @@ Civilian round				=	-10% damage for .223. AP reduced by 50%
 
 /obj/item/projectile/bullet/a762
 	name = "7.62 FMJ bullet"
-	damage = 39
-	armour_penetration = 0.25
+	damage = 34
+	armour_penetration = 0.2
 	wound_bonus = 20
 	bare_wound_bonus = -20
 
 /obj/item/projectile/bullet/a762/ap
 	name = "7.62 AP bullet"
-	damage = 31
-	armour_penetration = 0.45
+	damage = 29
+	armour_penetration = 0.4
 	wound_bonus = 10
 	bare_wound_bonus = -10
 
@@ -97,7 +97,7 @@ Civilian round				=	-10% damage for .223. AP reduced by 50%
 //.308 Winchester
 /obj/item/projectile/bullet/a762/sport 
 	name = ".308 bullet"
-	damage = 39
+	damage = 35
 	armour_penetration = 0.15
 
 /obj/item/projectile/bullet/a762/sport/simple //for simple mobs, separate to allow balancing
@@ -109,8 +109,8 @@ Civilian round				=	-10% damage for .223. AP reduced by 50%
 /////////			-Very heavy rifle round.
 
 /obj/item/projectile/bullet/a50MG
-	damage = 55
-	armour_penetration = 0.85
+	damage = 48
+	armour_penetration = 0.7
 	pixels_per_second = 4000
 
 /obj/item/projectile/bullet/a50MG/incendiary
@@ -140,8 +140,8 @@ Civilian round				=	-10% damage for .223. AP reduced by 50%
 
 /obj/item/projectile/bullet/a473
 	name = "4.73 FMJ bullet"
-	damage = 31
-	armour_penetration = 0.25
+	damage = 30
+	armour_penetration = 0.15
 	wound_bonus = 10
 	bare_wound_bonus = -10
 
@@ -167,6 +167,6 @@ Civilian round				=	-10% damage for .223. AP reduced by 50%
 /////////////////////////			- Gauss rifle
 
 /obj/item/projectile/bullet/c2mm
-	damage = 45
+	damage = 40
 	armour_penetration = 0.85
 	pixels_per_second = TILES_TO_PIXELS(100)

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,8 +1,8 @@
 /obj/item/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
-	damage = 49
+	damage = 46
 	sharpness = SHARP_POINTY
-	armour_penetration = 0.25
+	armour_penetration = 0.1
 	wound_bonus = 26
 	bare_wound_bonus = -26
 	spread = 2


### PR DESCRIPTION
## About The Pull Request

* All the top damage dealer ammos toned down a couple points, AP lowered for the biggest offenders.
* .38 detective no longer blows up
* The mindboggling amounts of resources in empty ammo boxes massively reduced.
* Autosears gets a nerf bat to the face since they still make some gun/tinker combos broken good. If not enough next step is delet.
* The mysterious superpower laser bolt of the lasmusket reduced to be a wattz2k one. The stats were "flavorful" to say the least.

Slows down combat a shade, makes some of the no brainer choices a little less OP, a small step in the direction ammo is going anyways with the armor rework, and since value adjustments are trivial its a good testbench to see how compressing the lethality towards the lower end of the spectrum is going to pan out. Let the rivers of salt flow.
