### PR TITLE
Blackpowder, with a side of napalm and money

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_forge.dm
+++ b/code/datums/components/crafting/recipes/recipes_forge.dm
@@ -177,7 +177,6 @@
 	time = 300
 	reqs = list(/obj/item/stack/sheet/metal = 5,
 				/obj/item/stack/sheet/cloth = 2)
-	tools = list(TOOL_FORGE)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 

--- a/code/datums/components/crafting/recipes/recipes_forge.dm
+++ b/code/datums/components/crafting/recipes/recipes_forge.dm
@@ -5,14 +5,16 @@
 /datum/crafting_recipe/forge
 	name = "Forge"
 	result = /obj/machinery/workbench/forge
-	reqs = list(/obj/item/stack/sheet/mineral/wood = 10,
-				/obj/item/lighter = 1,
-				/obj/item/twohanded/sledgehammer = 1,
-				/obj/item/screwdriver = 1,
-				/obj/item/crowbar = 1,
-				/obj/item/wrench = 1,
-				/obj/item/wirecutters = 1,
-				/obj/item/stack/sheet/metal = 50)
+	reqs = list(
+		/obj/item/stack/sheet/mineral/wood = 10,
+		/obj/item/lighter = 1,
+		/obj/item/twohanded/sledgehammer = 1,
+		/obj/item/screwdriver = 1,
+		/obj/item/crowbar = 1,
+		/obj/item/wrench = 1,
+		/obj/item/wirecutters = 1,
+		/obj/item/stack/sheet/metal = 50,
+		)
 	time = 400
 	category = CAT_CRAFTING
 	subcategory = CAT_FORGING
@@ -38,8 +40,10 @@
 /datum/crafting_recipe/ring_diamond
 	name = "Diamond Ring"
 	time = 30
-	reqs = list(/obj/item/stack/sheet/mineral/gold = 20,
-				/obj/item/stack/sheet/mineral/diamond = 10)
+	reqs = list(
+		/obj/item/stack/sheet/mineral/gold = 20,
+		/obj/item/stack/sheet/mineral/diamond = 10,
+		)
 	result = /obj/item/clothing/gloves/ring/diamond
 	tools = list(TOOL_FORGE)
 	category = CAT_CRAFTING
@@ -61,22 +65,15 @@
 	category = CAT_CRAFTING
 	subcategory = CAT_FORGING
 
-/datum/crafting_recipe/barrelfire
-	name = "Stoke barrel fire"
-	result = /obj/structure/campfire/barrel
-	reqs = list(/obj/item/stack/sheet/mineral/wood = 15,
-				/obj/item/stack/sheet/metal = 10)
-	time = 80
-	category = CAT_CRAFTING
-	subcategory = CAT_FORGING
-
 /datum/crafting_recipe/toolboxhammer
 	name = "Toolbox Hammer"
 	result = /obj/item/melee/smith/hammer/toolbox
 	tools = list(TOOL_SCREWDRIVER, TOOL_WRENCH, TOOL_WELDER)
-	reqs = list(/obj/item/storage/toolbox = 1,
-							/obj/item/stack/sheet/metal = 4,
-							/obj/item/stack/rods = 2)
+	reqs = list(
+		/obj/item/storage/toolbox = 1,
+		/obj/item/stack/sheet/metal = 4,
+		/obj/item/stack/rods = 2,
+		)
 	time = 40
 	category = CAT_CRAFTING
 	subcategory = CAT_FORGING
@@ -85,8 +82,10 @@
 	name = "Table Anvil"
 	result = /obj/structure/anvil/obtainable/table
 	time = 300
-	reqs = list(/obj/item/stack/sheet/metal = 4,
-				/obj/item/stack/rods = 2)
+	reqs = list(
+		/obj/item/stack/sheet/metal = 4,
+		/obj/item/stack/rods = 2,
+		)
 	tools = list(TOOL_SCREWDRIVER, TOOL_WRENCH, TOOL_WELDER)
 	category = CAT_CRAFTING
 	subcategory = CAT_FORGING
@@ -95,9 +94,11 @@
 	name = "Anvil"
 	result = /obj/structure/anvil/obtainable/basic
 	time = 450
-	reqs = list(/obj/item/stack/sheet/metal = 50,
-				/obj/item/stack/rods = 5,
-				/obj/item/stack/sheet/mineral/titanium = 15)
+	reqs = list(
+		/obj/item/stack/sheet/metal = 50,
+		/obj/item/stack/rods = 5,
+		/obj/item/stack/sheet/mineral/titanium = 15,
+		)
 	tools = list(TOOL_SCREWDRIVER, TOOL_WRENCH, TOOL_WELDER, TOOL_CROWBAR)
 	category = CAT_CRAFTING
 	subcategory = CAT_FORGING
@@ -133,9 +134,11 @@
 	name = "Sandstone Furnace"
 	result = /obj/structure/furnace
 	time = 300
-	reqs = list(/obj/item/stack/sheet/mineral/sandstone = 15,
-	/obj/item/stack/sheet/metal = 4,
-	/obj/item/stack/rods = 2)
+	reqs = list(
+		/obj/item/stack/sheet/mineral/sandstone = 15,
+		/obj/item/stack/sheet/metal = 4,
+		/obj/item/stack/rods = 2,
+		)
 	tools = list(TOOL_CROWBAR)
 	category = CAT_CRAFTING
 	subcategory = CAT_FORGING
@@ -143,8 +146,10 @@
 /datum/crafting_recipe/barrelfire
 	name = "Stoke barrel fire"
 	result = /obj/structure/campfire/barrel
-	reqs = list(/obj/item/stack/sheet/mineral/wood = 15,
-				/obj/item/stack/sheet/metal = 10)
+	reqs = list(
+		/obj/item/stack/sheet/mineral/wood = 15,
+		/obj/item/stack/sheet/metal = 10,
+		)
 	time = 80
 	category = CAT_CRAFTING
 	subcategory = CAT_FORGING
@@ -155,8 +160,10 @@
 	name = "Butchers Cleaver"
 	result = /obj/item/kitchen/knife/butcher
 	time = 100
-	reqs = list(/obj/item/stack/sheet/metal = 3,
-				/obj/item/stack/sheet/cloth = 1)
+	reqs = list(
+		/obj/item/stack/sheet/metal = 3,
+		/obj/item/stack/sheet/mineral/wood = 1,
+		)
 	tools = list(TOOL_FORGE)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
@@ -165,8 +172,11 @@
 	name = "Hunting Knife"
 	result = /obj/item/melee/onehanded/knife/hunting
 	time = 150
-	reqs = list(/obj/item/stack/sheet/metal = 3,
-				/obj/item/stack/sheet/cloth = 2)
+	reqs = list(
+		/obj/item/stack/sheet/metal = 3,
+		/obj/item/swordhandle = 1,
+		/obj/item/stack/sheet/cloth = 1,
+		)
 	tools = list(TOOL_FORGE)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
@@ -175,8 +185,10 @@
 	name = "Bayonet Knife"
 	result = /obj/item/melee/onehanded/knife/bayonet
 	time = 300
-	reqs = list(/obj/item/stack/sheet/metal = 5,
-				/obj/item/stack/sheet/cloth = 2)
+	reqs = list(
+		/obj/item/stack/sheet/metal = 6,
+		/obj/item/swordhandle = 1,
+		)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 
@@ -184,8 +196,10 @@
 	name = "Kitchen Knife"
 	result = /obj/item/kitchen/knife
 	time = 30
-	reqs = list(/obj/item/stack/sheet/metal = 2,
-				/obj/item/stack/sheet/cloth = 1)
+	reqs = list(
+		/obj/item/stack/sheet/metal = 2,
+		/obj/item/stack/sheet/mineral/wood = 1,
+		)
 	tools = list(TOOL_FORGE)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
@@ -194,8 +208,10 @@
 	name = "Survival Knife"
 	result = /obj/item/melee/onehanded/knife/survival
 	time = 100
-	reqs = list(/obj/item/stack/sheet/metal = 5,
-				/obj/item/stack/sheet/cloth = 1)
+	reqs = list(
+		/obj/item/stack/sheet/metal = 5,
+		/obj/item/swordhandle = 1,
+		)
 	tools = list(TOOL_FORGE)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
@@ -204,8 +220,10 @@
 	name = "Switchblade"
 	result = /obj/item/melee/onehanded/knife/switchblade
 	time = 40
-	reqs = list(/obj/item/stack/sheet/metal = 4,
-				/obj/item/stack/sheet/cloth = 1)
+	reqs = list(
+		/obj/item/stack/sheet/metal = 2,
+		/obj/item/stack/crafting/metalparts = 1,
+		)
 	tools = list(TOOL_FORGE)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
@@ -213,8 +231,10 @@
 /datum/crafting_recipe/melee/forged/bowie_knife
 	name = "Bowie Knife"
 	result = /obj/item/melee/onehanded/knife/bowie
-	reqs = list(/obj/item/stack/sheet/metal = 4,
-				/obj/item/stack/sheet/mineral/wood = 2)
+	reqs = list(
+		/obj/item/stack/sheet/metal = 8,
+		/obj/item/swordhandle = 1,
+		)
 	time = 200
 	tools = list(TOOL_FORGE)
 	category = CAT_WEAPONRY
@@ -223,9 +243,11 @@
 /datum/crafting_recipe/melee/forged/trench_knife
 	name = "Trench Knife"
 	result = /obj/item/melee/onehanded/knife/trench
-	reqs = list(/obj/item/stack/sheet/metal = 5,
-				/obj/item/stack/crafting/goodparts = 2,
-				/obj/item/stack/sheet/mineral/wood = 2)
+	reqs = list(
+		/obj/item/stack/sheet/metal = 5,
+		/obj/item/stack/crafting/goodparts = 2,
+		/obj/item/swordhandle = 1,
+		)
 	time = 280
 	tools = list(TOOL_FORGE)
 	category = CAT_WEAPONRY
@@ -235,8 +257,10 @@
 /datum/crafting_recipe/melee/forged/bmprsword
 	name = "Bumper Sword"
 	result = /obj/item/twohanded/fireaxe/bmprsword
-	reqs = list(/obj/item/stack/sheet/metal = 25,
-				/obj/item/stack/sheet/cloth = 2)
+	reqs = list(
+		/obj/item/stack/sheet/metal = 25,
+		/obj/item/stack/sheet/cloth = 2,
+		)
 	time = 400
 	tools = list(TOOL_FORGE)
 	category = CAT_WEAPONRY
@@ -245,23 +269,43 @@
 /datum/crafting_recipe/melee/forged/machete
 	name = "Machete"
 	result = /obj/item/melee/onehanded/machete/forgedmachete
-	reqs = list(/obj/item/stack/sheet/metal = 10,
-				/obj/item/stack/sheet/cloth = 2)
+	reqs = list(
+		/obj/item/stack/sheet/metal = 10,
+		/obj/item/stack/sheet/cloth = 1,
+		/obj/item/swordhandle = 1,
+		)
 	time = 180
 	tools = list(TOOL_FORGE)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
+
+
+/datum/crafting_recipe/spatha
+	name = "Scrap sabre"
+	result = /obj/item/melee/onehanded/machete/scrapsabre
+	reqs = list(
+		/obj/item/stack/sheet/metal = 18,
+		/obj/item/stack/sheet/leather = 2,
+		/obj/item/stack/sheet/plasteel = 2,
+	    )
+	time = 380
+	tools = list(TOOL_FORGE)
+	category = CAT_WEAPONRY
+	subcategory = CAT_MELEE
+	always_availible = FALSE
+
 
 // LEGION SPECIFIC
 
 /datum/crafting_recipe/spatha
 	name = "Spatha"
 	result = /obj/item/melee/onehanded/machete/spatha
-	reqs = list(/obj/item/stack/sheet/metal = 18,
-			/obj/item/stack/sheet/plasteel = 2,
-				/obj/item/stack/sheet/leather = 2, //custom hilt -
-				/obj/item/stack/sheet/bronze = 4,  //made from scratch -
-				/obj/item/stack/sheet/bone = 4)    //see desc for more info.
+	reqs = list(
+		/obj/item/stack/sheet/metal = 18,
+		/obj/item/stack/sheet/leather = 2,	//custom hilt -
+		/obj/item/stack/sheet/bronze = 2,	//made from scratch -
+		/obj/item/stack/sheet/bone = 2,	//see desc for more info.
+	    )
 	time = 380
 	tools = list(TOOL_FORGE)
 	category = CAT_WEAPONRY
@@ -271,9 +315,11 @@
 /datum/crafting_recipe/gladius
 	name = "Gladius"
 	result = /obj/item/melee/onehanded/machete/gladius
-	reqs = list(/obj/item/stack/sheet/metal = 15,
-				/obj/item/stack/sheet/cloth = 2,
-				/obj/item/swordhandle = 1) //objects of mass production don't require hilts more than 2 wood.
+	reqs = list(
+		/obj/item/stack/sheet/metal = 15,
+		/obj/item/stack/sheet/cloth = 1,
+		/obj/item/swordhandle = 1,
+		) 
 	time = 280
 	tools = list(TOOL_FORGE)
 	category = CAT_WEAPONRY
@@ -283,35 +329,42 @@
 /datum/crafting_recipe/legionshield
 	name = "Legion Shield"
 	result = /obj/item/shield/riot/legion
-	reqs = list(/obj/item/stack/sheet/metal = 8,
-				/obj/item/stack/sheet/mineral/wood = 8,
-				/obj/item/stack/sheet/leather = 2)
+	reqs = list(
+		/obj/item/stack/sheet/metal = 8,
+		/obj/item/stack/sheet/mineral/wood = 8,
+		/obj/item/stack/sheet/leather = 2,
+		)
 	time = 250
 	tools = list(TOOL_FORGE)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 	always_availible = FALSE
 
-/datum/crafting_recipe/lance
-	name = "Lance"
+/datum/crafting_recipe/legionlance
+	name = "Legion Lance"
 	result = /obj/item/twohanded/spear/lance
-	reqs = list(/obj/item/stack/sheet/metal = 20,
-				/obj/item/stack/sheet/mineral/wood = 6)
+	reqs = list(
+		/obj/item/stack/sheet/metal = 18,
+		/obj/item/stack/sheet/cloth = 1,
+		/obj/item/stack/sheet/mineral/wood = 6,
+		)
 	time = 180
 	tools = list(TOOL_FORGE)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 	always_availible = FALSE
 
-//polearms
 
+//polearms
 
 /datum/crafting_recipe/melee/forged/spear
 	name = "Spear"
 	result = /obj/item/twohanded/spear
 	time = 200
-	reqs = list(/obj/item/stack/sheet/metal = 16,
-				/obj/item/stack/sheet/mineral/wood = 4)
+	reqs = list(
+		/obj/item/stack/sheet/metal = 16,
+		/obj/item/stack/sheet/mineral/wood = 4,
+		)
 	tools = list(TOOL_FORGE)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
@@ -320,8 +373,10 @@
 	name = "Throwing Spear"
 	result = /obj/item/throwing_star/spear
 	time = 120
-	reqs = list(/obj/item/stack/sheet/metal = 2,
-				/obj/item/stack/sheet/mineral/wood = 3)
+	reqs = list(
+		/obj/item/stack/sheet/metal = 2,
+		/obj/item/stack/sheet/mineral/wood = 3,
+		)
 	tools = list(TOOL_FORGE)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
@@ -341,8 +396,10 @@
 	name = "Sappers"
 	result = /obj/item/melee/unarmed/sappers
 	time = 180
-	reqs = list(/obj/item/stack/sheet/metal = 3,
-				/obj/item/stack/sheet/lead = 2)
+	reqs = list(
+		/obj/item/stack/sheet/cloth = 3,
+		/obj/item/stack/sheet/lead = 2,
+		)
 	tools = list(TOOL_FORGE)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
@@ -359,8 +416,10 @@
 /datum/crafting_recipe/cosmicknife
 	name = "Cosmic Knife"
 	result = /obj/item/melee/onehanded/knife/cosmic
-	reqs = list(/obj/item/melee/onehanded/knife/cosmicdirty = 1,
-				/obj/item/crafting/abraxo = 1)
+	reqs = list(
+		/obj/item/melee/onehanded/knife/cosmicdirty = 1,
+		/obj/item/crafting/abraxo = 1,
+		)
 	tools = list(TOOL_WORKBENCH)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
@@ -369,8 +428,10 @@
 /datum/crafting_recipe/cosmicknifeheated
 	name = "Superheated Cosmic Knife"
 	result = /obj/item/melee/onehanded/knife/cosmicheated
-	reqs = list(/obj/item/melee/onehanded/knife/cosmic = 1,
-				/datum/reagent/fuel = 25)
+	reqs = list(
+		/obj/item/melee/onehanded/knife/cosmic = 1,
+		/datum/reagent/fuel = 25,
+		)
 	tools = list(TOOL_WORKBENCH)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
@@ -382,13 +443,14 @@
 // TOOLS //
 ///////////
 
-
 /datum/crafting_recipe/tools/forged/sledge
 	name = "Sledgehammer"
 	result = /obj/item/twohanded/sledgehammer
 	time = 700
-	reqs = list(/obj/item/stack/sheet/metal = 25,
-				/obj/item/stack/sheet/mineral/wood = 5)
+	reqs = list(
+		/obj/item/stack/sheet/metal = 25,
+		/obj/item/stack/sheet/mineral/wood = 5,
+		)
 	tools = list(TOOL_WORKBENCH, TOOL_WELDER)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
@@ -397,19 +459,22 @@
 	name = "Frying Pan"
 	result = /obj/item/melee/onehanded/club/fryingpan
 	time = 80
-	reqs = list(/obj/item/stack/sheet/metal = 5,
-				/obj/item/stack/sheet/mineral/wood = 1)
+	reqs = list(
+		/obj/item/stack/sheet/metal = 5,
+		/obj/item/stack/sheet/mineral/wood = 1,
+		)
 	tools = list(TOOL_FORGE)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
-
 
 /datum/crafting_recipe/tools/forged/pick_axe
 	name = "Pickaxe"
 	result = /obj/item/pickaxe
 	time = 150
-	reqs = list(/obj/item/stack/sheet/metal = 5,
-				/obj/item/stack/sheet/mineral/wood = 1)
+	reqs = list(
+		/obj/item/stack/sheet/metal = 5,
+		/obj/item/stack/sheet/mineral/wood = 1,
+		)
 	tools = list(TOOL_FORGE)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
@@ -418,8 +483,10 @@
 	name = "Shovel"
 	result = /obj/item/shovel
 	time = 150
-	reqs = list(/obj/item/stack/sheet/metal = 5,
-				/obj/item/stack/sheet/mineral/wood = 1)
+	reqs = list(
+		/obj/item/stack/sheet/metal = 2,
+		/obj/item/stack/sheet/mineral/wood = 3,
+		)
 	tools = list(TOOL_FORGE)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
@@ -428,8 +495,10 @@
 	name = "Hatchet"
 	result = /obj/item/hatchet
 	time = 80
-	reqs = list(/obj/item/stack/sheet/metal = 5,
-				/obj/item/stack/sheet/mineral/wood = 1)
+	reqs = list(
+		/obj/item/stack/sheet/metal = 5,
+		/obj/item/stack/sheet/mineral/wood = 2,
+		)
 	tools = list(TOOL_FORGE)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
@@ -438,82 +507,12 @@
 	name = "Pattern 2281 Entrenching Tool"
 	result = /obj/item/shovel/trench
 	time = 150
-	reqs = list(/obj/item/stack/sheet/metal = 5,
-				/obj/item/stack/sheet/cloth = 1,
-				/obj/item/stack/sheet/mineral/wood = 1)
+	reqs = list(
+		/obj/item/stack/sheet/metal = 5,
+		/obj/item/stack/sheet/cloth = 1,
+		/obj/item/stack/sheet/mineral/wood = 1,
+		)
 	tools = list(TOOL_FORGE)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 	always_availible = FALSE
-
-/*
-/datum/crafting_recipe/harpoon
-	name = "Harpoon"
-	result = /obj/item/throwing_star/spear/harpoon
-	time = 400
-	reqs = list(/obj/item/stack/sheet/metal = 5)
-	tools = list(TOOL_FORGE)
-	category = CAT_WEAPONRY
-	subcategory = CAT_MELEE
-
-/datum/crafting_recipe/throwingknife
-	name = "Throwing Knife"
-	result = /obj/item/throwing_star/throwingknife
-	reqs = list(/obj/item/stack/sheet/metal = 1,
-				/obj/item/stack/sheet/cloth = 1)
-	time = 300
-	tools = list(TOOL_FORGE)
-	category = CAT_WEAPONRY
-	subcategory = CAT_MELEE
-
-/datum/crafting_recipe/pipe
-	name = "Pipe"
-	result = /obj/item/melee/onehanded/club
-	time = 50
-	reqs = list(/obj/item/stack/sheet/metal = 5)
-	tools = list(TOOL_FORGE)
-	category = CAT_WEAPONRY
-	subcategory = CAT_MELEE
-
-/datum/crafting_recipe/cpick_axe
-	name = "Compact Pickaxe"
-	result = /obj/item/pickaxe/mini
-	time = 300
-	reqs = list(/obj/item/stack/sheet/metal = 5,
-				/obj/item/stack/sheet/mineral/wood = 1)
-	tools = list(TOOL_FORGE)
-	category = CAT_WEAPONRY
-	subcategory = CAT_MELEE
-
-/datum/crafting_recipe/plate
-	name = "Plate Armor"
-	result = /obj/item/clothing/suit/armor/plate/crusader/plate
-	time = 600
-	reqs = list(/obj/item/stack/sheet/metal = 30,
-				/obj/item/stack/sheet/cloth = 10)
-	tools = list(TOOL_FORGE)
-	category = CAT_WEAPONRY
-	subcategory = CAT_MELEE
-
-/datum/crafting_recipe/thejugg
-	name = "Juggernaut Armor"
-	result = /obj/item/clothing/suit/armor/plate/crusader/jugger
-	time = 1000
-	reqs = list(/obj/item/stack/sheet/metal = 90,
-				/obj/item/stack/sheet/cloth = 3)
-	tools = list(TOOL_FORGE)
-	category = CAT_WEAPONRY
-	subcategory = CAT_MELEE
-
-/datum/crafting_recipe/thejugghelm
-	name = "Juggernaut Helmet"
-	result = /obj/item/clothing/head/helmet/plate/crusader/jugger
-	time = 500
-	reqs = list(/obj/item/stack/sheet/metal = 30,
-				/obj/item/stack/sheet/cloth = 3)
-	tools = list(TOOL_FORGE)
-	category = CAT_WEAPONRY
-	subcategory = CAT_MELEE
-*/
-
-

--- a/code/datums/components/crafting/recipes/recipes_primal.dm
+++ b/code/datums/components/crafting/recipes/recipes_primal.dm
@@ -235,8 +235,10 @@
 	name = "Sturdy Arrow"
 	result = /obj/item/ammo_casing/caseless/arrow/ap
 	time = 40
-	reqs = list(/obj/item/stack/rods = 2,
-				/obj/item/stack/crafting/metalparts = 2)
+	reqs = list(
+		/obj/item/stack/rods = 2,
+		/obj/item/stack/crafting/metalparts = 2,
+		)
 	category = CAT_TRIBAL
 	tools = list(TOOL_WORKBENCH)
 
@@ -244,8 +246,10 @@
 	name = "Poison Arrow"
 	result = /obj/item/ammo_casing/caseless/arrow/poison
 	time = 30
-	reqs = list(/obj/item/ammo_casing/caseless/arrow = 1,
-				/obj/item/grown/nettle/basic = 5)
+	reqs = list(
+		/obj/item/ammo_casing/caseless/arrow = 1,
+		/obj/item/reagent_containers/food/snacks/grown/nettle = 5,
+		)
 	category = CAT_TRIBAL
 	tools = list(TOOL_WORKBENCH)
 

--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -49,18 +49,6 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 
-/*
-/datum/crafting_recipe/stunprod
-	name = "Stunprod"
-	result = /obj/item/melee/baton/cattleprod
-	reqs = list(/obj/item/restraints/handcuffs/cable = 1,
-				/obj/item/stack/rods = 1,
-				/obj/item/assembly/igniter = 1)
-	time = 40
-	category = CAT_WEAPONRY
-	subcategory = CAT_MELEE
-*/
-
 /datum/crafting_recipe/bola
 	name = "Bola"
 	result = /obj/item/restraints/legcuffs/bola
@@ -69,17 +57,6 @@
 	time = 20//15 faster than crafting them by hand!
 	category= CAT_WEAPONRY
 	subcategory = CAT_WEAPON
-
-///datum/crafting_recipe/chainsaw
-//	name = "Chainsaw"
-//	result = /obj/item/twohanded/chainsaw
-//	reqs = list(/obj/item/circular_saw = 1,
-//				/obj/item/stack/cable_coil = 3,
-//				/obj/item/stack/sheet/plasteel = 5)
-//	tools = list(TOOL_WELDER)
-//	time = 50
-//	category = CAT_WEAPONRY
-//	subcategory = CAT_MELEE
 
 //////////////////
 ///BOMB CRAFTING//
@@ -956,49 +933,7 @@
 	subcategory = CAT_WEAPON
 	always_availible = FALSE
 
-/*
-/widowmaker
-/datum/crafting_recipe/widowmaker
-	name = "Winchester Widowmaker double barrel"
-	result = /obj/item/gun/ballistic/revolver/widowmaker
-	reqs = list(/obj/item/stack/sheet/mineral/wood = 1,
-				/obj/item/stack/crafting/metalparts = 5,
-				/datum/reagent/blackpowder = 5)
-	tools = list(TOOL_WORKBENCH)
-	time = 120
-	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
-	always_availible = FALSE
 
-//ppsh
-/datum/crafting_recipe/pps
-	name = "Ppsh-41"
-	result = /obj/item/gun/ballistic/automatic/smg/ppsh
-	reqs = list(/obj/item/stack/sheet/metal = 5,
-				/obj/item/advanced_crafting_components/receiver = 1,
-				/obj/item/stack/crafting/metalparts = 2
-				)
-	tools = list(TOOL_WORKBENCH)
-	time = 120
-	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
-	always_availible = FALSE
-
-//fn fal
-/datum/crafting_recipe/fnfal
-	name = "FN-FAL"
-	result = /obj/item/gun/ballistic/automatic/fnfal
-	reqs = list(/obj/item/stack/sheet/mineral/wood = 1,
-				/obj/item/stack/crafting/metalparts = 2,
-				/obj/item/stack/sheet/metal = 3,
-				/obj/item/stack/sheet/mineral/titanium = 2,
-				/datum/reagent/blackpowder = 30)
-	tools = list(TOOL_WORKBENCH)
-	time = 120
-	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
-	always_availible = FALSE
-*/
 
 //////////////////////////////////
 ///GUN ATTACHMENT/PARTS CRAFTING//

--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -89,7 +89,7 @@
 	name = "Compressed Gunpowder"
 	result = /obj/item/stack/ore/blackpowder
 	time = 5
-	reqs = list(/datum/reagent/blackpowder = 50)
+	reqs = list(/datum/reagent/blackpowder = 30)
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
 

--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -89,7 +89,7 @@
 	name = "Compressed Gunpowder"
 	result = /obj/item/stack/ore/blackpowder
 	time = 5
-	reqs = list(/datum/reagent/blackpowder = 30)
+	reqs = list(/datum/reagent/blackpowder = 50)
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
 

--- a/code/game/objects/items/grenades/ghettobomb.dm
+++ b/code/game/objects/items/grenades/ghettobomb.dm
@@ -228,3 +228,9 @@
 
 /obj/item/export/bottle/attack_self(mob/user)
 	to_chat(user, "<span class='danger'>The seal seems fine. Best to not open it.</span>")
+
+
+/obj/item/reagent_containers/glass/bottle/napalm
+	name = "napalm mix"
+	desc = "Add this mix to the molotov cocktail before lighting it." 
+	list_reagents = list(/datum/reagent/napalm = 30)

--- a/code/game/objects/items/melee/f13onehanded.dm
+++ b/code/game/objects/items/melee/f13onehanded.dm
@@ -86,7 +86,7 @@
 	desc = "Made from materials found in the wastes, a skilled blacksmith has turned it into a thing of deadly beauty."
 	icon_state = "scrapsabre"
 	item_state = "scrapsabre"
-	force = 39
+	force = 37
 	block_chance = 15
 
 /obj/item/throwing_star/spear
@@ -644,8 +644,7 @@
 	icon_state = "brass"
 	item_state = "brass"
 	attack_verb = list("punched", "jabbed", "whacked")
-	force = 23
-
+	force = 24
 
 // Spiked knuckles	Keywords: Damage 24
 /obj/item/melee/unarmed/brass/spiked
@@ -653,8 +652,8 @@
 	desc = "Unlike normal brass knuckles, these have a metal plate across the knuckles with four spikes on, one for each knuckle. So not only does the victim feel the force of the punch, but also the devastating effects of spikes being driven in."
 	icon_state = "spiked"
 	item_state = "spiked"
-	force = 24
-
+	sharpness = SHARP_POINTY
+	force = 25
 
 // Sappers			Keywords: Damage 26
 /obj/item/melee/unarmed/sappers
@@ -662,9 +661,8 @@
 	desc = "Lead filled gloves which are ideal for beating the crap out of opponents."
 	icon_state = "sapper"
 	item_state = "sapper"
-	force = 26
 	w_class = WEIGHT_CLASS_NORMAL
-
+	force = 26
 
 // Tiger claws		Keywords: Damage 28, Pointy
 /obj/item/melee/unarmed/tigerclaw
@@ -672,12 +670,11 @@
 	desc = "Gloves with short claws built into the palms."
 	icon_state = "tiger_claw"
 	item_state = "tiger_claw"
-	force = 28
-	attack_verb = list("slashed", "sliced", "torn", "ripped", "diced", "cut")
-	hitsound = 'sound/weapons/bladeslice.ogg'
-	sharpness = SHARP_POINTY
 	w_class = WEIGHT_CLASS_NORMAL
-
+	attack_verb = list("slashed", "sliced", "torn", "ripped", "diced", "cut")
+	sharpness = SHARP_POINTY
+	force = 28
+	hitsound = 'sound/weapons/bladeslice.ogg'
 
 // Lacerator		Keywords: Damage 27, Edged, Wound bonus
 /obj/item/melee/unarmed/lacerator
@@ -685,24 +682,22 @@
 	desc = "Leather gloves with razor blades built into the back of the hand."
 	icon_state = "lacerator"
 	item_state = "lacerator"
+	w_class = WEIGHT_CLASS_NORMAL
 	force = 27
+	bare_wound_bonus = 5
+	sharpness = SHARP_EDGED
 	attack_verb = list("slashed", "sliced", "torn", "ripped", "diced", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	sharpness = SHARP_EDGED
-	w_class = WEIGHT_CLASS_NORMAL
-	bare_wound_bonus = 5
 
-
-// Mace Glove		Keywords: Damage 30
+// Mace Glove		Keywords: Damage 31
 /obj/item/melee/unarmed/maceglove
 	name = "mace glove"
 	desc = "Weighted metal gloves that are covered in spikes.  Don't expect to grab things with this."
 	icon_state = "mace_glove"
 	item_state = "mace_glove"
-	force = 30
-	sharpness = SHARP_NONE
 	w_class = WEIGHT_CLASS_BULKY
-
+	force = 31
+	sharpness = SHARP_NONE
 
 // Punch Dagger		Keywords: Damage 29, Pointy
 /obj/item/melee/unarmed/punchdagger
@@ -711,10 +706,9 @@
 	icon_state = "punch_dagger"
 	item_state = "punch_dagger"
 	force = 29
+	sharpness = SHARP_POINTY
 	attack_verb = list("stabbed", "sliced", "pierced", "diced", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	sharpness = SHARP_POINTY
-
 
 // Deathclaw Gauntlet	Keywords: Damage 28, AP 1
 /obj/item/melee/unarmed/deathclawgauntlet
@@ -722,14 +716,13 @@
 	desc = "The severed hand of a mighty Deathclaw, cured, hollowed out, and given a harness to turn it into the deadliest gauntlet the wastes have ever seen."
 	icon_state = "deathclaw_g"
 	item_state = "deathclaw_g"
-	force = 28
-	armour_penetration = 1
-	attack_verb = list("slashed", "sliced", "torn", "ripped", "diced", "cut")
-	hitsound = 'sound/weapons/bladeslice.ogg'
-	sharpness = SHARP_EDGED
 	slot_flags = ITEM_SLOT_GLOVES
 	w_class = WEIGHT_CLASS_NORMAL
-
+	force = 28
+	armour_penetration = 1
+	sharpness = SHARP_EDGED
+	attack_verb = list("slashed", "sliced", "torn", "ripped", "diced", "cut")
+	hitsound = 'sound/weapons/bladeslice.ogg'
 
 
 ///////////
@@ -758,12 +751,12 @@
 	righthand_file = 'icons/fallout/onmob/weapons/melee1h_righthand.dmi'
 	icon_state = "entrenching_tool"
 	item_state = "trench"
+	w_class = WEIGHT_CLASS_NORMAL
 	force = 30
 	throwforce = 15
-	w_class = WEIGHT_CLASS_NORMAL
 	toolspeed = 0.7
-	attack_verb = list("cleaved", "chopped", "sliced", "slashed")
 	sharpness = SHARP_EDGED
+	attack_verb = list("cleaved", "chopped", "sliced", "slashed")
 
 // Hatchet
 /obj/item/hatchet

--- a/code/game/objects/items/stacks/crafting.dm
+++ b/code/game/objects/items/stacks/crafting.dm
@@ -75,7 +75,7 @@
 	merge_type = /obj/item/stack/crafting/powder
 
 GLOBAL_LIST_INIT(powder_recipes, list ( \
-	new/datum/stack_recipe("Scavenge blackpowder", /obj/item/reagent_containers/glass/bottle/blackpowder, 100),\
+	new/datum/stack_recipe("Scavenge blackpowder", /obj/item/reagent_containers/glass/bottle/blackpowder, 50),\
 ))
 
 ///obj/item/stack/crafting/powder/Initialize(mapload, new_amount, merge = TRUE)

--- a/code/game/objects/items/stacks/crafting.dm
+++ b/code/game/objects/items/stacks/crafting.dm
@@ -70,12 +70,12 @@
 	desc = "A pouch containing some scoops of blackpowder and empty shell casings."
 	icon_state = "sheet-powder"
 	singular_name = "bullet remnant"
-	max_amount = 200
+	max_amount = 240
 	full_w_class = WEIGHT_CLASS_SMALL
 	merge_type = /obj/item/stack/crafting/powder
 
 GLOBAL_LIST_INIT(powder_recipes, list ( \
-	new/datum/stack_recipe("Scavenge blackpowder", /obj/item/reagent_containers/glass/bottle/blackpowder, 50),\
+	new/datum/stack_recipe("Scavenge blackpowder", /obj/item/reagent_containers/glass/bottle/blackpowder, 80),\
 ))
 
 ///obj/item/stack/crafting/powder/Initialize(mapload, new_amount, merge = TRUE)

--- a/code/modules/crafting/items.dm
+++ b/code/modules/crafting/items.dm
@@ -982,6 +982,7 @@
 	Loot = list(/obj/item/blueprint/research,
 				/obj/item/reagent_containers/hypospray/medipen/stimpak,
 				/obj/item/reagent_containers/pill/patch/healingpowder,
+				/obj/item/stack/ore/blackpowder/two,
 				/obj/item/weldingtool/advanced,
 				/obj/item/crowbar/hightech,
 				/obj/item/screwdriver/hightech,

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -830,7 +830,7 @@ commented out pending rework*/
 		/obj/item/ammo_box/a357 = 3,
 		/obj/item/melee/onehanded/machete = 1,
 		/obj/item/reagent_containers/food/drinks/bottle/molotov = 2,
-		/obj/item/reagent_containers/glass/bottle/welding_fuel = 2,
+		/obj/item/reagent_containers/glass/bottle/napalm = 2,
 		/obj/item/lighter/greyscale = 1,
 		)
 

--- a/code/modules/mining/money_bag.dm
+++ b/code/modules/mining/money_bag.dm
@@ -51,7 +51,7 @@
 /obj/item/storage/bag/money/small/legion/PopulateContents()
 	// ~450ish worth of legion money
 	new /obj/item/stack/f13Cash/random/denarius/high(src)
-	new /obj/item/stack/f13Cash/random/denarius/high(src)
+	new /obj/item/stack/f13Cash/random/denarius/med(src)
 	new /obj/item/stack/f13Cash/random/aureus/high(src)
 
 // Legion enlisted. Spawns with the Legionnaires. Average 12 caps.

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -7,7 +7,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	throwforce = 0
 	w_class = WEIGHT_CLASS_TINY
-	custom_materials = list(/datum/material/iron = 500, /datum/material/blackpowder=20)
+	custom_materials = list(/datum/material/iron = 500, /datum/material/blackpowder=10)
 	var/fire_sound = null						//What sound should play when this ammo is fired
 	var/caliber = null							//Which kind of guns it can be loaded into
 	var/projectile_type = null					//The bullet type to create when New() is called

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -7,7 +7,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	throwforce = 0
 	w_class = WEIGHT_CLASS_TINY
-	custom_materials = list(/datum/material/iron = 500, /datum/material/blackpowder=10)
+	custom_materials = list(/datum/material/iron = 500, /datum/material/blackpowder=20)
 	var/fire_sound = null						//What sound should play when this ammo is fired
 	var/caliber = null							//Which kind of guns it can be loaded into
 	var/projectile_type = null					//The bullet type to create when New() is called

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -10,7 +10,7 @@
 /obj/item/ammo_box/shotgun
 	icon = 'icons/fallout/objects/guns/ammo.dmi'
 	max_ammo = 12
-	custom_materials = list(/datum/material/iron = 6000, /datum/material/blackpowder = 1500)
+	custom_materials = list(/datum/material/iron = 6000, /datum/material/blackpowder = 1000)
 	ammo_type = /obj/item/ammo_casing/shotgun
 	multiple_sprites = 1
 	
@@ -63,7 +63,7 @@
 	ammo_type = /obj/item/ammo_casing/a22
 	max_ammo = 40
 	w_class = WEIGHT_CLASS_SMALL
-	custom_materials = list(/datum/material/iron = 6000, /datum/material/blackpowder = 1500)
+	custom_materials = list(/datum/material/iron = 6000, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/m22/plinking
 	name = "ammo box (.22lr plinking)"
@@ -73,7 +73,7 @@
 /obj/item/ammo_box/m22/hp
 	name = "ammo box (.22lr hollow point)"
 	ammo_type = /obj/item/ammo_casing/a22/hp
-	custom_materials = list(/datum/material/iron = 8000, /datum/material/blackpowder = 2000)
+	custom_materials = list(/datum/material/iron = 8000, /datum/material/blackpowder = 1500)
 
 
 //9mm and .38
@@ -85,12 +85,12 @@
 	caliber = "9mm"
 	ammo_type = /obj/item/ammo_casing/c9mm
 	max_ammo = 30
-	custom_materials = list(/datum/material/iron = 15000, /datum/material/blackpowder = 1500)
+	custom_materials = list(/datum/material/iron = 15000, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/c9mm/ap
 	name = "ammo box (9mm AP)"
 	ammo_type = /obj/item/ammo_casing/c9mm/ap
-	custom_materials = list(/datum/material/iron = 15000, /datum/material/titanium = 3750, /datum/material/blackpowder = 2000)
+	custom_materials = list(/datum/material/iron = 15000, /datum/material/titanium = 3750, /datum/material/blackpowder = 1500)
 
 /obj/item/ammo_box/c9mm/jhp
 	name = "ammo box (9mm JHP)"
@@ -100,7 +100,7 @@
 /obj/item/ammo_box/c9mm/op
 	name = "ammo box (9mm +P)"
 	ammo_type = /obj/item/ammo_casing/c9mm/op
-	custom_materials = list(/datum/material/iron = 19000, /datum/material/blackpowder = 3500)
+	custom_materials = list(/datum/material/iron = 19000, /datum/material/blackpowder = 2500)
 
 /obj/item/ammo_box/c38box
 	name = "ammo box (.38)"
@@ -135,7 +135,7 @@
 /obj/item/ammo_box/c10mm/jhp
 	name = "ammo box (10mm JHP)"
 	ammo_type = /obj/item/ammo_casing/c10mm/jhp
-	custom_materials = list(/datum/material/iron = 6000, /datum/material/blackpowder = 1500)
+	custom_materials = list(/datum/material/iron = 6000, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/c10mm/fire
 	name = "ammo box (10mm Incendiary)"
@@ -145,7 +145,7 @@
 /obj/item/ammo_box/c10mm/ap
 	name = "ammo box (10mm AP)"
 	ammo_type = /obj/item/ammo_casing/c10mm/ap
-	custom_materials = list(/datum/material/iron = 14000, /datum/material/titanium = 3500, /datum/material/blackpowder = 1500)
+	custom_materials = list(/datum/material/iron = 14000, /datum/material/titanium = 3000, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/c10mm/improvised
 	name = "bag with reloaded 10mm bullets"
@@ -164,18 +164,18 @@
 	caliber = "357"
 	ammo_type = /obj/item/ammo_casing/a357
 	max_ammo = 30
-	custom_materials = list(/datum/material/iron = 16000, /datum/material/blackpowder = 1500)
+	custom_materials = list(/datum/material/iron = 16000, /datum/material/blackpowder = 1000)
 	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/ammo_box/a357box/jhp
 	name = "ammo box (.357 Magnum JHP)"
 	ammo_type = /obj/item/ammo_casing/a357/jhp
-	custom_materials = list(/datum/material/iron = 12000, /datum/material/blackpowder = 1500)
+	custom_materials = list(/datum/material/iron = 12000, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/a357box/jfp
 	name = "ammo box (.357 Magnum JFP)"
 	ammo_type = /obj/item/ammo_casing/a357/jfp
-	custom_materials = list(/datum/material/iron = 19000, /datum/material/blackpowder = 2000)
+	custom_materials = list(/datum/material/iron = 19000, /datum/material/blackpowder = 1000)
 
 
 //.44 Magnum
@@ -188,17 +188,17 @@
 	ammo_type = /obj/item/ammo_casing/m44
 	max_ammo = 30
 	w_class = WEIGHT_CLASS_NORMAL
-	custom_materials = list(/datum/material/iron = 14000, /datum/material/blackpowder = 1500)
+	custom_materials = list(/datum/material/iron = 14000, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/m44box/jhp
 	name = "ammo box (.44 Magnum JHP)"
 	ammo_type = /obj/item/ammo_casing/m44/jhp
-	custom_materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1500)
+	custom_materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/m44box/swc
 	name = "ammo box (.44 Magnum SWC)"
 	ammo_type = /obj/item/ammo_casing/m44/swc
-	custom_materials = list(/datum/material/iron = 19000, /datum/material/blackpowder = 2000)
+	custom_materials = list(/datum/material/iron = 19000, /datum/material/blackpowder = 1500)
 
 /obj/item/ammo_box/a45lcbox
 	name = "ammo box (.45 Long Colt)"
@@ -228,7 +228,7 @@
 	icon_state = "45box"
 	ammo_type = /obj/item/ammo_casing/c45
 	max_ammo = 30
-	custom_materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1500)
+	custom_materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/c45/jhp
 	name = "ammo box (.45 JHP)"
@@ -238,7 +238,7 @@
 /obj/item/ammo_box/c45/op
 	name = "ammo box (.45 +P)"
 	ammo_type = /obj/item/ammo_casing/c45/op
-	custom_materials = list(/datum/material/iron = 14000, /datum/material/blackpowder = 2000)
+	custom_materials = list(/datum/material/iron = 14000, /datum/material/blackpowder = 1500)
 
 /obj/item/ammo_box/c45/improvised
 	name = "bag with reloaded .45 ACP bullets"
@@ -259,17 +259,17 @@
 	ammo_type = /obj/item/ammo_casing/c4570
 	max_ammo = 30
 	w_class = WEIGHT_CLASS_NORMAL
-	custom_materials = list(/datum/material/iron = 16000, /datum/material/blackpowder = 2000)
+	custom_materials = list(/datum/material/iron = 16000, /datum/material/blackpowder = 1500)
 
 /obj/item/ammo_box/c4570box/jhp
 	name = "ammo box (.45-70 JHP)"
 	ammo_type = /obj/item/ammo_casing/c4570/jhp
-	custom_materials = list(/datum/material/iron = 12000, /datum/material/blackpowder = 2000)
+	custom_materials = list(/datum/material/iron = 12000, /datum/material/blackpowder = 1500)
 
 /obj/item/ammo_box/c4570box/swc
 	name = "ammo box (.45-70 SWC)"
 	ammo_type = /obj/item/ammo_casing/c4570/swc
-	custom_materials = list(/datum/material/iron = 20000, /datum/material/blackpowder = 3500)
+	custom_materials = list(/datum/material/iron = 20000, /datum/material/blackpowder = 2500)
 
 
 //5.56x45
@@ -282,22 +282,22 @@
 	ammo_type = /obj/item/ammo_casing/a556
 	max_ammo = 40
 	w_class = WEIGHT_CLASS_NORMAL
-	custom_materials = list(/datum/material/iron = 20000, /datum/material/blackpowder = 1500)
+	custom_materials = list(/datum/material/iron = 20000, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/a556/jhp
 	name = "ammo box (5.56 JHP)"
 	ammo_type = /obj/item/ammo_casing/a556/jhp
-	custom_materials = list(/datum/material/iron = 16000, /datum/material/blackpowder = 1500)
+	custom_materials = list(/datum/material/iron = 16000, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/a556/ap
 	name = "ammo box (5.56 AP)"
 	ammo_type = /obj/item/ammo_casing/a556/ap
-	custom_materials = list(/datum/material/iron = 24000, /datum/material/titanium = 6000, /datum/material/blackpowder = 1500)
+	custom_materials = list(/datum/material/iron = 24000, /datum/material/titanium = 4000, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/a556/match
 	name = "ammo box (5.56 match)"
 	ammo_type = /obj/item/ammo_casing/a556/match
-	custom_materials = list(/datum/material/iron = 28000, /datum/material/blackpowder = 3500)
+	custom_materials = list(/datum/material/iron = 28000, /datum/material/blackpowder = 2500)
 
 /obj/item/ammo_box/a556/sport
 	name = "ammo box (.223 sport)"
@@ -334,7 +334,7 @@
 	ammo_type = /obj/item/ammo_casing/a762
 	max_ammo = 30
 	w_class = WEIGHT_CLASS_NORMAL
-	custom_materials = list(/datum/material/iron = 16000, /datum/material/blackpowder = 1500)
+	custom_materials = list(/datum/material/iron = 16000, /datum/material/blackpowder = 1000)
 
 /obj/item/ammo_box/a762box/jhp
 	name = "ammo box (7.62x51 JHP)"
@@ -344,12 +344,12 @@
 /obj/item/ammo_box/a762box/ap
 	name = "ammo box (7.62x51 AP)"
 	ammo_type = /obj/item/ammo_casing/a762/ap
-	custom_materials = list(/datum/material/iron = 20000, /datum/material/titanium = 5000, /datum/material/blackpowder = 2000)
+	custom_materials = list(/datum/material/iron = 20000, /datum/material/titanium = 4000, /datum/material/blackpowder = 1500)
 
 /obj/item/ammo_box/a762box/match
 	name = "ammo box (7.62x51 Match)"
 	ammo_type = /obj/item/ammo_casing/a762/match
-	custom_materials = list(/datum/material/iron = 28000, /datum/material/blackpowder = 3500)
+	custom_materials = list(/datum/material/iron = 28000, /datum/material/blackpowder = 2500)
 
 
 //.50 MG and 14mm
@@ -362,7 +362,7 @@
 	ammo_type = /obj/item/ammo_casing/a50MG
 	max_ammo = 25
 	w_class = WEIGHT_CLASS_NORMAL
-	custom_materials = list(/datum/material/iron = 20000, /datum/material/blackpowder = 2000)
+	custom_materials = list(/datum/material/iron = 20000, /datum/material/blackpowder = 1500)
 
 /obj/item/ammo_box/m14mm
 	name = "ammo box (14mm)"
@@ -425,7 +425,7 @@
 
 /obj/item/ammo_box/tube
 	icon = 'icons/fallout/objects/guns/ammo.dmi'
-	custom_materials = list(/datum/material/iron = 6000)
+	custom_materials = list(/datum/material/iron = 4000)
 	multiple_sprites = 1
 
 //.38
@@ -437,7 +437,7 @@
 	ammo_type = /obj/item/ammo_casing/c38
 	max_ammo = 6
 	multiple_sprites = 1
-	custom_materials = list(/datum/material/iron = 3000)
+	custom_materials = list(/datum/material/iron = 2000)
 
 /obj/item/ammo_box/c38/empty
 	start_empty = 1
@@ -452,7 +452,7 @@
 	ammo_type = /obj/item/ammo_casing/c10mm
 	max_ammo = 12
 	multiple_sprites = 1
-	custom_materials = list(/datum/material/iron = 3000)
+	custom_materials = list(/datum/material/iron = 2000)
 
 /obj/item/ammo_box/l10mm/empty
 	start_empty = 1
@@ -467,7 +467,7 @@
 	caliber = "357"
 	max_ammo = 6
 	multiple_sprites = 1
-	custom_materials = list(/datum/material/iron = 3000)
+	custom_materials = list(/datum/material/iron = 2000)
 
 /obj/item/ammo_box/a357/match
 	name = "speed loader (.357 Match)"
@@ -501,7 +501,7 @@
 	max_ammo = 6
 	caliber = "44"
 	multiple_sprites = 1
-	custom_materials = list(/datum/material/iron = 3000)
+	custom_materials = list(/datum/material/iron = 2000)
 
 /obj/item/ammo_box/m44/empty
 	start_empty = 1
@@ -528,7 +528,7 @@
 	ammo_type = /obj/item/ammo_casing/c45
 	max_ammo = 7
 	multiple_sprites = 1
-	custom_materials = list(/datum/material/iron = 3000)
+	custom_materials = list(/datum/material/iron = 2000)
 
 /obj/item/ammo_box/c45rev/empty
 	start_empty = 1
@@ -541,7 +541,7 @@
 	ammo_type = /obj/item/ammo_casing/a45lc
 	max_ammo = 6
 	multiple_sprites = 1
-	custom_materials = list(/datum/material/iron = 3000)
+	custom_materials = list(/datum/material/iron = 2000)
 
 /obj/item/ammo_box/a45lcrev/empty
 	start_empty = 1
@@ -556,7 +556,7 @@
 	ammo_type = /obj/item/ammo_casing/c4570
 	max_ammo = 6
 	multiple_sprites = 1
-	custom_materials = list(/datum/material/iron = 3000)
+	custom_materials = list(/datum/material/iron = 2000)
 
 /obj/item/ammo_box/c4570/empty
 	start_empty = 1
@@ -633,7 +633,7 @@
 	ammo_type = /obj/item/ammo_casing/a762
 	max_ammo = 5
 	multiple_sprites = 1
-	custom_materials = list(/datum/material/iron = 3000)
+	custom_materials = list(/datum/material/iron = 2000)
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/ammo_box/a308
@@ -644,7 +644,7 @@
 	ammo_type = /obj/item/ammo_casing/a762/sport
 	max_ammo = 5
 	multiple_sprites = 1
-	custom_materials = list(/datum/material/iron = 3000)
+	custom_materials = list(/datum/material/iron = 2000)
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/ammo_box/a762/doublestacked
@@ -655,7 +655,7 @@
 	ammo_type = /obj/item/ammo_casing/a762/sport
 	max_ammo = 10
 	multiple_sprites = 1
-	custom_materials = list(/datum/material/iron = 3000)
+	custom_materials = list(/datum/material/iron = 2000)
 	w_class = WEIGHT_CLASS_SMALL
 
 //5.56x45mm
@@ -666,7 +666,7 @@
 	ammo_type = /obj/item/ammo_casing/a556
 	max_ammo = 5
 	multiple_sprites = 1
-	custom_materials = list(/datum/material/iron = 3000)
+	custom_materials = list(/datum/material/iron = 2000)
 	w_class = WEIGHT_CLASS_SMALL
 
 

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -89,16 +89,6 @@
 	. = ..()
 	safe_calibers = magazine.caliber
 
-/obj/item/gun/ballistic/revolver/detective/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0, stam_cost = 0)
-	if(chambered && !(chambered.caliber in safe_calibers))
-		if(prob(70 - (magazine.ammo_count() * 10)))	//minimum probability of 10, maximum of 60
-			playsound(user, fire_sound, 50, 1)
-			to_chat(user, "<span class='userdanger'>[src] blows up in your face!</span>")
-			user.take_bodypart_damage(0,20)
-			user.dropItemToGround(src)
-			return FALSE
-	..()
-
 /obj/item/gun/ballistic/revolver/detective/screwdriver_act(mob/living/user, obj/item/I)
 	if(..())
 		return TRUE


### PR DESCRIPTION
## About The Pull Request

EDIT: The amount of blackpowder you get from scavenging is increased by about 20%.

Also adds napalm bottle to the assets and bundles it with the molotovs in loadouts.
Adjusts the Legion reserve money spawner a little since it was closer to 600 than what the description  said (450)
EDIT: Slapped on the poison arrow fix.
Aaand the .38 detecive fix
aand the improvised bayonet recipe accidentally having the forge requirement. Boom!
Since in forging had to fix a bunch of recipes, legion lance and explosive had the same path, two barrel stoke fires, various costs adjusted so stuff cost closer to other similar blades.
Gunpowder in empty ammo boxes lowered a little since casings went up, couple of little used melee weapons got tiny adjustments.
