### PR TITLE
Town Radio Fix

### DIFF
--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -440,6 +440,10 @@ em {
   color: #a8732b;
 }
 
+.townradio {
+  color: #4779f4;
+}
+
 .legionradio {
   color: #c24d44;
 }

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -464,6 +464,10 @@ em {
   color: #a8732b;
 }
 
+.townradio {
+  color: #4779f4;
+}
+
 .legionradio {
   color: #c24d44;
 }


### PR DESCRIPTION
## About The Pull Request

Fixes Oasis radio chatter not having its own color. Uses #4779f4, a shade of blue. Tested on a private build without issue.