### PR TITLE
Removes need for a workbench from pot belly stove

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_assemblies.dm
+++ b/code/datums/components/crafting/recipes/recipes_assemblies.dm
@@ -178,7 +178,7 @@
 	reqs = list(/obj/item/stack/crafting/metalparts = 3,
 				/obj/item/stack/crafting/goodparts = 2,
 				/obj/item/stack/sheet/metal = 10)
-	tools = list(TOOL_WELDER, TOOL_WORKBENCH)
+	tools = list(TOOL_WELDER)
 	time = 80
 	subcategory = CAT_FARMING
 	category = CAT_MISC


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the need for a workbench from pot belly stove crafting. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The pot belly stove is an unmoveable campfire structure. As such it seemed strange that you needed a workbench to create it, as you would need to drag that workbench over to where you wanted to create the object rather than just make it.
Suggested by venom#9542 on discord.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: removed the need for a workbench from the pot belly stove campfire.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
