### PR TITLE
Adds bear trap crafting

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_assemblies.dm
+++ b/code/datums/components/crafting/recipes/recipes_assemblies.dm
@@ -214,3 +214,4 @@
 	time = 80
 	subcategory = CAT_FARMING
 	category = CAT_MISC
+

--- a/code/datums/components/crafting/recipes/recipes_assemblies.dm
+++ b/code/datums/components/crafting/recipes/recipes_assemblies.dm
@@ -203,3 +203,14 @@
 	tools = list(TOOL_WORKBENCH)
 	subcategory = CAT_FARMING
 	category = CAT_MISC
+
+/datum/crafting_recipe/beartrap
+	name = "Bear trap"
+	result = /obj/item/restraints/legcuffs/beartrap
+	reqs = list(/obj/item/stack/crafting/metalparts = 10,
+				/obj/item/stack/crafting/goodparts = 5,
+				/obj/item/crafting = 2) //For the mechanism of the bear trap, crafting parts are needed.
+	tools = list(TOOL_WORKBENCH)
+	time = 80
+	subcategory = CAT_FARMING
+	category = CAT_MISC

--- a/code/datums/components/crafting/recipes/recipes_assemblies.dm
+++ b/code/datums/components/crafting/recipes/recipes_assemblies.dm
@@ -209,9 +209,8 @@
 	result = /obj/item/restraints/legcuffs/beartrap
 	reqs = list(/obj/item/stack/crafting/metalparts = 10,
 				/obj/item/stack/crafting/goodparts = 5,
-				/obj/item/crafting = 2) //For the mechanism of the bear trap, crafting parts are needed.
+				/obj/item/crafting = 2,) //For the mechanism of the bear trap, crafting parts are needed.
 	tools = list(TOOL_WORKBENCH)
 	time = 80
 	subcategory = CAT_FARMING
 	category = CAT_MISC
-


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the ability to craft bear traps with ten metal parts, five high quality metal parts, and 2 crafting components. Underneath the farming crafting table.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Trapping and trappers rejoice! Now you can lay down bear traps and capture your prey with ease. This is a PR created at the recommendation of 𝐋𝐀𝐍𝐃𝐒𝐊𝐍𝐄𝐂𝐇𝐓. (𝐌𝐎𝐍𝐎𝐋𝐈𝐓𝐇#2051 on discord) who wanted more booby traps for their booby trap character. 

The requirements of high quality metal parts and crafting componenets have been added to prevent waves and waves of bear traps coating the desert, while still allowing people to use them in their defences. Please feel free to suggest recipe changes if you are not happy with my current costs!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added bear trap crafting to the farming tab
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
