### PR TITLE
Fixes booze dispenser by renaming beer (details inside)

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -80,7 +80,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	return ..()
 
 /datum/reagent/consumable/ethanol/beer
-	name = "Beer"
+	name = "Regular Beer"
 	description = "An alcoholic beverage brewed since ancient times on Old Earth. Still popular today."
 	color = "#664300" // rgb: 102, 67, 0
 	nutriment_factor = 1 * REAGENTS_METABOLISM


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Renames beer to "Regular Beer", allowing the booze dispenser to dispense beer again.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As it turns out, due to the fact that dispensers use chem names as ID's, some reagents share IDs, causing them to freak the dispenser out and not dispense anything (e.g. Traitor borg toxin beer and regular beer both have the name ID as they are both just "Beer"). 
In order to fix this and allow barkeeps to use beer again without having to hunt down a keg, I have simply renamed beer... to regular beer! **_This still works with reactions as it is not a path rename but a simple rename._**

I do not intend this to be a proper fix, but rather a temporary "band-aid" one while I (or someone smarter than me) can unf*ck chem ID code.
This also sorts out #431 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: renames beer reagent, fixes beer dispensing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
