### PR TITLE
Adds the ability to bonk someone's head on disarm

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1539,7 +1539,7 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 
 		target.visible_message(\
 			"<span class='danger'>\The [user] bonks [user == target ? "[user.p_them()]self" : "\the [target]"] on the head!</span>",\
-			"<span class='notice'>[user] slaps you in the face! </span>",\
+			"<span class='notice'>[user] bonks you on the head! </span>",\
 			"You hear a bonk.", target = user, target_message = "<span class='notice'>You bonk [user == target ? "yourself" : "\the [target]"] on the head! </span>")
 		user.do_attack_animation(target, ATTACK_EFFECT_FACE_SLAP)
 		user.adjustStaminaLossBuffered(3)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -647,7 +647,7 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 	//Warpaint and tattoos
 	if(H.warpaint)
 		standing += mutable_appearance('icons/mob/tribe_warpaint.dmi', H.warpaint, -MARKING_LAYER, color = H.warpaint_color)
-		
+
 
 	if(standing.len)
 		H.overlays_standing[BODY_LAYER] = standing
@@ -1491,6 +1491,8 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 	var/same_dir = (target.dir & user.dir)
 	var/aim_for_groin  = user.zone_selected == "groin"
 	var/target_aiming_for_groin = target.zone_selected == "groin"
+	var/aim_for_head = user.zone_selected == "head"
+	var/target_aiming_for_head = target.zone_selected == "head"
 
 	if(target.check_martial_melee_block()) //END EDIT
 		target.visible_message("<span class='warning'>[target] blocks [user]'s disarm attempt!</span>", target = user, \
@@ -1529,6 +1531,18 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 			"<span class='notice'>[user] slaps your ass! </span>",\
 			"You hear a slap.", target = user, target_message = "<span class='notice'>You slap [user == target ? "your own" : "\the [target]'s"] ass! </span>")
 
+		return FALSE
+
+//BONK chucklehead!
+	else if(aim_for_head && ( target_on_help || target_restrained || target_aiming_for_head))
+		playsound(target.loc, 'sound/weapons/klonk.ogg', 50, 1, -1)
+
+		target.visible_message(\
+			"<span class='danger'>\The [user] bonks [user == target ? "[user.p_them()]self" : "\the [target]"] on the head!</span>",\
+			"<span class='notice'>[user] slaps you in the face! </span>",\
+			"You hear a bonk.", target = user, target_message = "<span class='notice'>You bonk [user == target ? "yourself" : "\the [target]"] on the head! </span>")
+		user.do_attack_animation(target, ATTACK_EFFECT_FACE_SLAP)
+		user.adjustStaminaLossBuffered(3)
 		return FALSE
 
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the ability to bonk people's head on disarm, much like how you can boop nose (mouth area) or pat their head.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
PR made at the request of cornercube#2639 on discord. Need to playfully (not harmfully) bonk someone on the head for being an absolute idiot? Now you can! 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added head bonking on disarm.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
