### PR TITLE
shotgun nerf

### DIFF
--- a/code/game/objects/items/melee/f13powerfist.dm
+++ b/code/game/objects/items/melee/f13powerfist.dm
@@ -12,7 +12,6 @@
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	flags_1 = CONDUCT_1
 	attack_verb = list("whacked", "fisted", "power-punched")
-	force = 25
 	armour_penetration = 0.5
 	throwforce = 10
 	throw_range = 3
@@ -62,7 +61,6 @@
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	flags_1 = CONDUCT_1
-	force = 40
 	armour_penetration = 0.4
 	throwforce = 10
 	throw_range = 7

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -110,7 +110,6 @@
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 0.5
-	extra_damage = 2
 	force = 20
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/dual/simple
 	sawn_desc = "Short and concealable, terribly uncomfortable to fire, but worse on the other end."
@@ -146,7 +145,6 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/dual
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
-	extra_damage = 1
 	fire_delay = 0.5
 	force = 20
 	sawn_desc = "Someone took the time to chop the last few inches off the barrel and stock of this shotgun. Now, the wide spread of this hand-cannon's short-barreled shots makes it perfect for short-range crowd control."
@@ -198,7 +196,7 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/police
 	sawn_desc = "Portable but with a poor recoil managment."
 	w_class = WEIGHT_CLASS_NORMAL
-	extra_damage = 1
+	extra_damage = 0
 	recoil = 0.5
 	var/stock = FALSE
 	can_flashlight = TRUE
@@ -275,7 +273,7 @@
 			select = 0
 			burst_size = 1
 			spread = 2
-			extra_damage = 2
+			extra_damage = 1
 			to_chat(user, "<span class='notice'>You go back to firing the shotgun one round at a time.</span>")
 
 
@@ -319,7 +317,7 @@
 	icon_state = "shotgunlever"
 	item_state = "shotgunlever"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/trench
-	extra_damage = 2
+	extra_damage = 1
 	fire_delay = 7
 	recoil = 0.5
 	w_class = WEIGHT_CLASS_NORMAL
@@ -391,6 +389,7 @@
 	icon_state = "shotgunriot"
 	item_state = "shotgunriot" 
 	w_class = WEIGHT_CLASS_BULKY
+	untinkerable = TRUE
 	mag_type = /obj/item/ammo_box/magazine/d12g
 	fire_delay = 6
 	burst_size = 1

--- a/code/modules/projectiles/guns/hoboguns.dm
+++ b/code/modules/projectiles/guns/hoboguns.dm
@@ -140,6 +140,7 @@
 	item_state = "shotgunbat"
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_MEDIUM
+	untinkerable = TRUE
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/improvised
 	force = 26 //Good club
 	fire_delay = 0.5

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -111,7 +111,7 @@
 
 /obj/item/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"
-	damage = 11
+	damage = 10
 	wound_bonus = 5
 	bare_wound_bonus = 5
 	wound_falloff_tile = -2.5 // low damage + additional dropoff will already curb wounding potential anything past point blank


### PR DESCRIPTION
All shotties untinkerable
Pellets 10 dam instead of 11
Mole miners 42 max damage instead of 120 something.
Shotties max dam bonus +1, most at 0

Since 6x11 dam + tinker shotguns is just not ok (84 dam double barrel was not unusual)
