### PR TITLE
Defib timer + Wasteland loadout (Baron PR)

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -295,7 +295,7 @@ GLOBAL_LIST_INIT(pda_reskins, list(PDA_SKIN_CLASSIC = 'icons/obj/pda.dmi'))
 #define MAP_MAXZ 6
 
 // Defib stats
-#define DEFIB_TIME_LIMIT 1500
+#define DEFIB_TIME_LIMIT 600
 #define DEFIB_TIME_LOSS 60
 
 // Diagonal movement

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1397,25 +1397,13 @@ obj/item/storage/box/stingbangs
 	for(var/i in 1 to 7)
 		new /obj/item/card/id/dogtag/town(src)
 
-/obj/item/storage/box/vendingmachine
-	name = "Vending Machine Kit"
-	desc = "A box containing all the necessary items to construct a vending machine."
-/*
-list(/obj/item/stack/sheet/metal = 20,
-				/obj/item/stack/crafting/metalparts = 10,
-				/obj/item/stack/crafting/electronicparts = 5,
-				/obj/item/stack/crafting/goodparts = 10,
-				/obj/item/stack/cable_coil = 10)
-*/
 
-/obj/item/storage/box/vendingmachine/PopulateContents()
-	. = ..()
-	new /obj/item/stack/sheet/metal/twenty(src)
-	new /obj/item/stack/crafting/metalparts/five(src)
-	new /obj/item/stack/crafting/metalparts/five(src)
-	new /obj/item/stack/crafting/electronicparts/five(src)
-	new /obj/item/stack/crafting/goodparts/five(src)
-	new /obj/item/stack/crafting/goodparts/five(src)
-	new /obj/item/stack/cable_coil/ten(src)
-	new /obj/item/screwdriver(src)
-	new /obj/item/weldingtool(src)
+obj/item/storage/box/vendingmachine/PopulateContents()
+	var/static/items_inside = list(
+		/obj/item/stack/sheet/metal = 10,
+		/obj/item/stack/crafting/metalparts = 5,
+		/obj/item/stack/crafting/electronicparts = 5,
+		/obj/item/stack/crafting/goodparts = 3,
+		/obj/item/stack/cable_coil = 1
+		)
+	generate_items_inside(items_inside, src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
There were changes requested by Baron#9800
Changed the defib timer from 25 minutes to ten.
Changed the wastelander loadout to contain less materials (10 HQM was A LOT, it'd equal 50 titanium)
## Why It's Good For The Game
Desert Rose implemented a timer of which does not fit our overarching vision for a much more genuine urgency when it comes to death; of course, this'll be balanced in time with better changes to the lingering overabundance of weapons and materials intended for a much more player-versus-environment server, modifying the defibrillation time from a whopping twenty five minutes to ten minutes is a reasonable first step in the appropriate direction. 

Furthermore - reducing the amount of metal the 'Roving Trader' role can receive on loadout, ten high quality metal is an unnecessary amount of resources which further inflates the already bulbous wasteland economy. - Baron
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
