### PR TITLE
Adjustment of PA Thresholds

### DIFF
--- a/code/modules/clothing/suits/f13armor.dm
+++ b/code/modules/clothing/suits/f13armor.dm
@@ -219,7 +219,7 @@
 	var/armor_block_chance = 0 //Chance for the power armor to block a low penetration projectile
 	protected_zones = list(BODY_ZONE_CHEST, BODY_ZONE_PRECISE_GROIN, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
 	var/deflection_chance = 0 //Chance for the power armor to redirect a blocked projectile
-	var/armor_block_threshold = 0.3 //projectiles below this will deflect
+	var/armor_block_threshold = 0.2 //projectiles below this will deflect
 	var/melee_block_threshold = 30
 	var/dmg_block_threshold = 42
 	var/powerLevel = 7000
@@ -486,7 +486,7 @@
 	armor_block_chance = 70
 	deflection_chance = 10 //35% chance to block damage from blockable bullets and redirect the bullet at a random angle. Less overall armor compared to T-60, but higher deflection.
 	armor = list("tier" = 10, "energy" = 65, "bomb" = 62, "bio" = 100, "rad" = 99, "fire" = 90, "acid" = 0, "wound" = 70)
-	armor_block_threshold = 0.35
+	armor_block_threshold = 0.25
 	melee_block_threshold = 35
 
 /obj/item/clothing/suit/armor/f13/power_armor/t51b/tesla
@@ -525,7 +525,7 @@
 	armor = list("tier" = 11, "energy" = 70, "bomb" = 82, "bio" = 100, "rad" = 100, "fire" = 95, "acid" = 0, "wound" = 80)
 
 	melee_block_threshold = 40
-	armor_block_threshold = 0.4
+	armor_block_threshold = 0.3
 	armor_block_chance = 80
 	deflection_chance = 15 //20% chance to block damage from blockable bullets and redirect the bullet at a random angle. Same deflection as T-45 due to it having the same general shape.
 
@@ -553,7 +553,7 @@
 	armor = list("tier" = 12, "energy" = 75, "bomb" = 72, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 0, "wound" = 90)
 
 	melee_block_threshold = 45
-	armor_block_threshold = 0.45
+	armor_block_threshold = 0.4
 	armor_block_chance = 80 //Enclave. 'nuff said
 	deflection_chance = 15 //40% chance to block damage from blockable bullets and redirect the bullet at a random angle. Your ride's over mutie, time to die.
 
@@ -596,7 +596,7 @@
 	icon_state = "advanced"
 	item_state = "advanced"
 	slowdown = 0.15 //+0.1 from helmet = total 0.25
-	armor_block_threshold = 0.35
+	armor_block_threshold = 0.3
 	melee_block_threshold = 35
 	armor_block_chance = 70
 	deflection_chance = 10

--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -669,6 +669,7 @@
 	icon_state = "heavy_tribal_armor"
 	item_state = "heavy_tribal_armor"
 	armor = list("tier" = 5, "energy" = 45, "bomb" = 55, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
+	slowdown = 0.15
 	flags_inv = HIDEJUMPSUIT
 	allowed = list(/obj/item/gun, /obj/item/kitchen, /obj/item/twohanded, /obj/item/claymore, /obj/item/melee/onehanded, /obj/item/twohanded/spear, /obj/item/melee/smith, /obj/item/melee/smith/twohand
 )


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the threshold values for PA's to be appropiate for the reducted AP values.
Changes to Tribal 20 metal 5 cloth armor to not be straight up superior to the combat armor (Yet still remaining true to it's theme)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
AP values were decreased for obvious reason in previous PR's, but the thresholds for PA's weren't. This resulted in AP being completely useless against PA's while JHP was the most effective ammo (Due to surpassing the damage thresholds) This is the opposite of what the ammo-types are supposed to do. I've adjusted the AP values to a point where the PA will still be useful at blocking non-AP weapons and smaller calibers yet not block 7.62 AP (Rangemaster, sniper rifle and bolt actions.) It'll still block .44 in most cases, and also non-AP 5.56 (depending on the Power Armor)

The adjustment of the tribal heavy armor was to make room for the tribal combat armor and also very slightly reduce powercreep (Not in any meaningful way). The HEAVY tribal armor is now heavy and slows, previously it had no slowly and provided tier 5 protection (which it still does). This means that the tribal heavy armor was straight up a combat armor for 20 metal and 5 cloth, by adding a slowdown I've managed to give the tribals a reason to craft their combat armor which they have a variant of.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
