### PR TITLE
Sets Wayfarer slots to zero

### DIFF
--- a/code/modules/jobs/job_types/tribals.dm
+++ b/code/modules/jobs/job_types/tribals.dm
@@ -44,8 +44,8 @@ Tribal Chief
 	flag = F13CHIEF
 	department_flag = TRIBAL
 	faction = "Village"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	supervisors = "The Elders of the tribe."
 	enforces = "The ways of the Machine spirits."
 	forbids = "Abusing technology and using Pre-Collapse weapons."
@@ -89,8 +89,8 @@ Tribal Shaman
 	flag = F13SHAMAN
 	department_flag = TRIBAL
 	faction = "Village"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	supervisors = "The Elders of the tribe and the chief."
 	enforces = "The ways of the Machine spirits."
 	forbids = "Abusing technology and using Pre-Collapse weapons."
@@ -164,8 +164,8 @@ Tribal Head Hunter
 	flag = F13HHUNTER
 	department_flag = TRIBAL
 	faction = "Village"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	supervisors = "The Elders of the tribe and the chief."
 	enforces = "The ways of the Machine spirits."
 	forbids = "Abusing technology and using Pre-Collapse weapons."
@@ -218,8 +218,8 @@ Druid
 	flag = F13DRUID
 	department_flag = TRIBAL
 	faction = "Village"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	supervisors = "The Chief and the Shaman."
 	enforces = "The ways of the Machine spirits."
 	forbids = "Abusing technology and using Pre-Collapse weapons."
@@ -277,8 +277,8 @@ Villager
 	flag = F13VILLAGER
 	department_flag = TRIBAL
 	faction = "Village"
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 0
+	spawn_positions = 0
 	supervisors = "Tribal Chief, Shaman and Headhunter"
 	description = "A proud member of the Wayfarer tribe, you do what needs to be done to ensure the survival of yourself and your people while following the laws of the tribe. While it is common to venture out into the wasteland, do not tread far or without informing your kin."
 	selection_color = "#006666"
@@ -370,8 +370,8 @@ Hunter
 	flag = F13HUNTER
 	department_flag = TRIBAL
 	faction = "Village"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	supervisors = "The chief and Head Hunter."
 	enforces = "The ways of the Machine spirits."
 	forbids = "Abusing technology and using Pre-Collapse weapons."
@@ -454,8 +454,8 @@ Spirit-Pledged
 	flag = F13SPIRITPLEDGED
 	department_flag = TRIBAL
 	faction = "Village"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	supervisors = "All other tribals."
 	description = "An outsider to the tribe, you have been welcomed to learn their ways and grow closer to their culture and lifestyle, do NOT run off alone into the wasteland without the supervision of another higher ranking tribal."
 	selection_color = "#006666"
@@ -490,8 +490,8 @@ Guardian
 	flag = F13GUARDIAN
 	department_flag = TRIBAL
 	faction = "Village"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	supervisors = "All leadership, but the Chief is priority"
 	description = "A hand chosen Hunter with much promise, you are one of the village Guardians. An elite Hunter given the duty to protect the village, your duty is to ensure your kin are safe at all costs, as well as follow any orders from your superiors and enforce the law of the tribe. Do not leave the village unless circumstances allow it."
 	selection_color = "#006666"


### PR DESCRIPTION
With the pop dip a golden opportunity has come to fix some of the legacy issues from Bad Deathclaw and Desert Rose.
Use  the good from them, discard the bad, and there is a real need to make sure the players are not isolated too much from each other.

I love tribals in theory, in practice Wayfarers always been a snowflakey mess, the whole no guns but OP melee/archery/armor to compensate never sat right with me, and their role in the faction setup always was kind of lame, pointless isolationism, lore and theme that was somewhat lacking.

Solution is to set tribe faction slots to zero. Playing tribal still fine, via Wastelander and Outlaw slots.
Let Wayfarers die so Den and Oasis can live and grow healthier, not enough sunshine for all to go around.