### PR TITLE
new herlooms

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -46,7 +46,7 @@ GLOBAL_LIST_EMPTY(family_heirlooms)
 	var/obj/item/heirloom_type
 	switch(quirk_holder.mind.assigned_role)
 		if("Scribe")
-			heirloom_type = pick(/obj/item/trash/f13/electronic/toaster, /obj/item/screwdriver/crude
+			heirloom_type = pick(/obj/item/trash/f13/electronic/toaster, /obj/item/screwdriver/crude)
 		if("Sheriff")
 			heirloom_type = /obj/item/clothing/accessory/medal
 		if("Shopkeeper")

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -45,16 +45,16 @@ GLOBAL_LIST_EMPTY(family_heirlooms)
 	var/mob/living/carbon/human/H = quirk_holder
 	var/obj/item/heirloom_type
 	switch(quirk_holder.mind.assigned_role)
-		if("Cook")
-			heirloom_type = /obj/item/kitchen/knife/butcher
-		if("Botanist")
-			heirloom_type = pick(/obj/item/cultivator, /obj/item/reagent_containers/glass/bucket, /obj/item/storage/bag/plants, /obj/item/toy/plush/beeplushie)
-		if("Medical Doctor")
-			heirloom_type = /obj/item/healthanalyzer
-		if("Paramedic")
-			heirloom_type = /obj/item/lighter
-		if("Station Engineer")
-			heirloom_type = /obj/item/wirecutters/brass
+		if("Scribe")
+			heirloom_type = pick(/obj/item/trash/f13/electronic/toaster, /obj/item/screwdriver/crude
+		if("Sheriff")
+			heirloom_type = /obj/item/clothing/accessory/medal
+		if("Shopkeeper")
+			heirloom_type = /obj/item/coin/plasma
+		if("Followers Doctor")
+			heirloom_type = /obj/item/clothing/neck/stethoscope
+		if("Prime Legionnaire")
+			heirloom_type = pick(/obj/item/melee/onehanded/machete, /obj/item/melee/onehanded/club/warclub, /obj/item/toy/plush/mr_buckety) 
 		if("Atmospheric Technician")
 			heirloom_type = /obj/item/extinguisher/mini/family
 		if("Lawyer")
@@ -74,8 +74,9 @@ GLOBAL_LIST_EMPTY(family_heirlooms)
 	if(!heirloom_type)
 		heirloom_type = pick(
 		/obj/item/toy/cards/deck,
+		/obj/item/card/id/rusted,
 		/obj/item/lighter,
-		/obj/item/dice/d20)
+		/obj/item/card/id/rusted/fadedvaultid,)
 	heirloom = new heirloom_type(get_turf(quirk_holder))
 	GLOB.family_heirlooms += heirloom
 	var/list/slots = list(

--- a/code/modules/jobs/job_types/oasis.dm
+++ b/code/modules/jobs/job_types/oasis.dm
@@ -180,7 +180,7 @@ Mayor
 	satchel = /obj/item/storage/backpack/satchel/explorer
 	l_pocket = /obj/item/storage/bag/money/small/settler
 	r_pocket = /obj/item/flashlight/flare
-	r_hand = /obj/item/melee/onehanded/knife/hunting = 1
+	r_hand = /obj/item/melee/onehanded/knife/hunting
 	shoes = /obj/item/clothing/shoes/f13/explorer
 	uniform = /obj/item/clothing/under/f13/cowboyb
 	backpack_contents = list(

--- a/code/modules/jobs/job_types/oasis.dm
+++ b/code/modules/jobs/job_types/oasis.dm
@@ -180,12 +180,11 @@ Mayor
 	satchel = /obj/item/storage/backpack/satchel/explorer
 	l_pocket = /obj/item/storage/bag/money/small/settler
 	r_pocket = /obj/item/flashlight/flare
-	r_hand = /obj/item/gun/ballistic/rifle/repeater/trail
+	r_hand = /obj/item/melee/onehanded/knife/hunting = 1
 	shoes = /obj/item/clothing/shoes/f13/explorer
 	uniform = /obj/item/clothing/under/f13/cowboyb
 	backpack_contents = list(
 		/obj/item/restraints/handcuffs = 1,
-		/obj/item/melee/onehanded/knife/hunting = 1,
 		/obj/item/storage/belt/holster = 1,
 		)
 		


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

a small number of jobs get specific heirlooms

## Why It's Good For The Game

everyone getting the same 3 heirlooms was lame
and non-thematic, as the D20 is a symbol of TG not FO
they were all tiny objects as well, so essentially a free trait point, so now you have a small chance to get something big enough to eat up a backpack slot

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: followers doctor, sheriff, shopkeep, prime legionary, and scribe get new heirlooms, generic heirloom pool now has faded IDs in it (former vaultie anyone?)
