### PR TITLE
intel spec fix & BoS remnant changes

### DIFF
--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -289,7 +289,8 @@
 	suit_store =	/obj/item/gun/ballistic/automatic/pistol/n99/enclave
 	accessory =	/obj/item/clothing/accessory/ncr/SPC
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/m10mm_adv/ext = 2,
+		/obj/item/ammo_box/magazine/m10mm_adv = 3,
+		/obj/item/suppressor = 1,
 		/obj/item/clothing/head/helmet/f13/helmet/enclave/intel = 1,
 		/obj/item/storage/firstaid/regular = 1,
 		/obj/item/storage/box/mre/menu2 = 1,

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -464,8 +464,9 @@ Raider
 	shoes = /obj/item/clothing/shoes/combat/swat
 	l_hand = /obj/item/gun/energy/laser/wattz
 	backpack_contents = list(
-		/obj/item/stock_parts/cell/ammo/ec = 3,
+		/obj/item/stock_parts/cell/ammo/ec = 2,
 		/obj/item/reagent_containers/food/snacks/f13/mre = 1,
+		/obj/item/radio/headset/headset_bos = 1,
 		)
 
 /datum/outfit/loadout/medic

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -795,7 +795,7 @@
 	spread = 8
 	recoil = 0.1
 	can_attachments = TRUE
-	can_bayonet = FALSE
+	can_bayonet = TRUE
 	bayonet_state = "rifles"
 	knife_x_offset = 23
 	knife_y_offset = 11
@@ -896,6 +896,10 @@
 	spread = 9
 	recoil = 0.1
 	can_attachments = TRUE
+	can_bayonet = TRUE
+	bayonet_state = "bayonet"
+	knife_x_offset = 22
+	knife_y_offset = 21
 	can_scope = TRUE
 	scope_state = "scope_short"
 	scope_x_offset = 4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

intel specialist was spawning with mags that don't fit in the gun they're given, also didn't get the intended suppressor because I forgot. ALSO gave BoS remnant a brotherhood radio headset to give them the potential to link up with other remnants in-round potentially creating a lot of rp and player born factions.

## Why It's Good For The Game

fixes the intel spec loadout to have all the stuff it should. and gives the BoS remnant a free xbox 360 headset mic

## Changelog
:cl:
-enclave intel specialist loadout changes
-BoS remnant wastelander loadout changes
-allows r91 assault rifle & assault carbine to take bayonets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
