### PR TITLE
Enclave XL70E3 & other changes

### DIFF
--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -94,7 +94,7 @@
 	outfit = /datum/outfit/job/enclave/armor
 
 /datum/outfit/job/enclave/armor
-	name = "Enclave Armored Infantry"
+	name = "Enclave Sergeant"
 	jobtype = /datum/job/enclave/armor
 	head =	/obj/item/clothing/head/helmet/f13/power_armor/x02helmet
 	mask =	/obj/item/clothing/mask/gas/enclave
@@ -125,7 +125,7 @@
 // PRIVATE
 
 /datum/job/enclave/soldier
-	title = "Enclave Soldier"
+	title = "Enclave Private"
 	flag = F13USPRIVATE
 	faction = "Enclave"
 	total_positions = 4
@@ -142,7 +142,7 @@
 	outfit = /datum/outfit/job/enclave/soldier
 
 /datum/outfit/job/enclave/soldier
-	name =	"Enclave Soldier"
+	name =	"Enclave Private"
 	jobtype =	/datum/job/enclave/soldier
 	head =	/obj/item/clothing/head/helmet/f13/helmet/enclave/peacekeeper
 	mask =	/obj/item/clothing/mask/gas/enclave
@@ -150,7 +150,7 @@
 	uniform =	/obj/item/clothing/under/f13/enclave
 	suit =	/obj/item/clothing/suit/armor/f13/enclave
 	accessory =	/obj/item/clothing/accessory/enclave/soldier
-	suit_store =	/obj/item/gun/ballistic/automatic/assault_rifle
+	suit_store =	/obj/item/gun/ballistic/automatic/assault_carbine
 
 	backpack_contents = list(
 		/obj/item/grenade/smokebomb = 1,
@@ -168,8 +168,8 @@
 	title = "Enclave Corporal"
 	flag = F13USCORPORAL
 	faction = "Enclave"
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 2
+	spawn_positions = 2
 	description = "You are a member of a dying breed, true Americans, but you will do what you can to help revitalize the nation, and protect her from all enemies, foreign and domestic."
 	supervisors = "You report to the Sergeants directly."
 	selection_color = "#323232"
@@ -192,7 +192,7 @@
 	gloves =	/obj/item/clothing/gloves/rifleman
 	accessory =	/obj/item/clothing/accessory/ncr/CPL
 	belt =	/obj/item/storage/belt/military/assault/enclave
-	suit_store = /obj/item/gun/ballistic/automatic/assault_carbine
+	suit_store = /obj/item/gun/ballistic/automatic/xl70e3
 	backpack_contents = list(
 		/obj/item/gun/energy/laser/pistol = 1,
 		/obj/item/stock_parts/cell/ammo/ec = 1,
@@ -216,8 +216,8 @@
 	title = "Enclave Scientist"
 	flag = F13USSCIENTIST
 	faction = "Enclave"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 2
+	spawn_positions = 2
 	description = "You're responsible for the maintenance of the base, the knowledge you've accumulated over the years is the only thing keeping the remnants alive. You've dabbled in enough to be considered a Professor in proficiency, but they call you Doctor. Support your dwindling forces and listen to the Lieutenant."
 	forbids = "The Enclave forbids you from leaving the base alone while it is still habitable."
 	enforces = "You must maintain the secrecy of organization."
@@ -270,8 +270,8 @@
 	title = "Intelligence Specialist"
 	flag = F13USMEDIC
 	faction = "Enclave"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 2
+	spawn_positions = 2
 	description = "You are a US Secret Service Operative broadly tasked with ensuring the continued existence of your current post, you're free to assist the scientists, go completely undercover within another organisation, or simply act as a Paramedic for local forces."
 	supervisors = "The United States Secret Service"
 

--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -203,7 +203,7 @@
 		/obj/item/storage/box/mre/menu4 = 1,
 		)
 
-/datum/outfit/job/enclave/armor/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/job/enclave/corporal/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
 	if(visualsOnly)
 		return

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -1151,20 +1151,30 @@
 	fire_sound = 'sound/f13weapons/gauss_rifle.ogg'
 
 /obj/item/gun/ballistic/automatic/xl70e3
-	name = "xl70e3"
+	name = "XL70E3"
 	desc = "This was an experimental weapon at the time of the war. Manufactured, primarily, from high-strength polymers, the weapon is almost indestructible. It's light, fast firing, accurate, and can be broken down without the use of any tools. Chamebered in 5.56mm."
 	icon_state = "xl70e3"
 	item_state = "xl70e3"
 	mag_type = /obj/item/ammo_box/magazine/m556/rifle
-	fire_delay = 2
+	extra_damage = 3
+	fire_delay = 4
 	burst_shot_delay = 2
 	spawnwithmagazine = TRUE
 	spread = 4
-	can_attachments = TRUE
+	can_attachments = FALSE
 	zoomable = TRUE
 	zoom_amt = 10
 	zoom_out_amt = 13
 	can_scope = FALSE
+	can_bayonet = TRUE
+	bayonet_state = "rifles"
+	knife_x_offset = 22
+	knife_y_offset = 12
+	can_suppress = TRUE
+	suppressor_state = "suppressor"
+	suppressor_x_offset = 31
+	suppressor_y_offset = 15
+	fire_sound = 'sound/f13weapons/marksman_rifle.ogg'
 
 
 // BETA STUFF // =Obsolete

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -1175,6 +1175,7 @@
 	suppressor_x_offset = 31
 	suppressor_y_offset = 15
 	fire_sound = 'sound/f13weapons/marksman_rifle.ogg'
+	untinkerable = TRUE
 
 
 // BETA STUFF // =Obsolete


### PR DESCRIPTION
Adds a rebalanced untikerable XL70E3 which wasn't currently in use as a weapon specific to enclave corporals, basically statistically a marksman carbine with a 2rnd burst (+3 extra damage) but it can't take a burst cam or be tinkered meaning it's outclassed by most other 5.56 automatics if they're modded, alongside this privates get their assault carbine back because it's statistically identical to the R91 minus being able to take a scope & a seclite as mods.

Enclave Scientist now has 2 slots, Corporal has been lowered from 3 to 2 and Intel Specialist got a second slot because more people have been wanting to play it & it isn't a particularly powerful loadout with it's funny 10mm pistol, also finish the rename of 'Armored Infantry' to 'Sergeant' which has been sitting there not done for like 2 weeks aswell as 'Soldier' to 'Private'.

![image](https://user-images.githubusercontent.com/89287800/131869883-7afcfbcc-8e4f-4286-8350-1b2c84b6824d.png)
