### PR TITLE
Auto-reset

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -180,7 +180,7 @@ ALLOW_ADMIN_OOCCOLOR
 ID_CONSOLE_JOBSLOT_DELAY 30
 
 ## allow players to initiate a restart vote
-ALLOW_VOTE_RESTART
+# ALLOW_VOTE_RESTART
 
 ## allow players to initiate a crew transfer vote
 ALLOW_VOTE_TRANSFER
@@ -196,7 +196,7 @@ VOTE_PERIOD 600
 
 ## autovote initial delay (deciseconds) before first automatic transfer vote call (default 120 minutes)
 ## Set to 0 to disable the subsystem altogether.
-VOTE_AUTOTRANSFER_INITIAL 0
+VOTE_AUTOTRANSFER_INITIAL 144000
 
 ## autovote delay (deciseconds) before sequential automatic transfer votes are called (default 30 minutes)
 VOTE_AUTOTRANSFER_INTERVAL 0
@@ -204,7 +204,7 @@ VOTE_AUTOTRANSFER_INTERVAL 0
 ## autovote maximum votes until automatic transfer call. (default 4)
 ## Set to 0 to force automatic crew transfer after the 'vote_autotransfer_initial' elapsed.
 ## Set to -1 to disable the maximum votes cap.
-VOTE_AUTOTRANSFER_MAXIMUM -1
+VOTE_AUTOTRANSFER_MAXIMUM 0
 
 ## prevents dead players from voting or starting votes
 # NO_DEAD_VOTE


### PR DESCRIPTION
Sets automatic restart vote every 4 hours to keep it refreshed for players who join when no staff around.
Think its a good idea.
Not familiar with this command but it looks like it will work, give it a try.