### PR TITLE
enclave changes & stock r91 bugfix

### DIFF
--- a/code/__DEFINES/access.dm
+++ b/code/__DEFINES/access.dm
@@ -102,7 +102,7 @@ also be like that but I can't be arsed to go back and change them all*/
 #define ACCESS_NCROFFDUTY	132 //general NCR access
 #define ACCESS_CLINIC		133 //Oasis clinic access
 #define ACCESS_ENCLAVE 		134 //enclave general
-#define ACCESS_ENCLAVE_RD	135 //enclave research
+#define ACCESS_ENCLAVE_RD	135 //enclave command
 	//The Syndicate
 #define ACCESS_SYNDICATE 150//General Syndicate Access. Includes Syndicate mechs and ruins.
 #define ACCESS_SYNDICATE_LEADER 151//Nuke Op Leader Access

--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -153,6 +153,7 @@
 	desc = "A light, replaceable armored vest issued usually as part of a suit of advanced combat armor."
 	icon_state = "armor_enclave_peacekeeper"
 	item_state = "armor_enclave_peacekeeper"
+	armor = list("tier" = 4, "energy" = 20, "bomb" = 30, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
 
 /obj/item/clothing/suit/armor/f13/enclave/corporal
 	name = "US Army Combat Armor"

--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -99,8 +99,6 @@
 	supervisors = "the United States Government."
 	selection_color = "#323232"
 	outfit = /datum/outfit/job/enclave/scientist
-	access = list(ACCESS_ENCLAVE, ACCESS_ENCLAVE_RD)
-	minimal_access = list(ACCESS_ENCLAVE, ACCESS_ENCLAVE_RD)
 
 /datum/outfit/job/enclave/scientist
 	name =	"Enclave Scientist"
@@ -148,6 +146,8 @@
 	description = "You are a US Secret Service Operative broadly tasked with ensuring the continued existence of your current post, you're free to assist the scientists, go completely undercover within another organisation, or simply act as a Paramedic for local forces."
 	supervisors = "The United States Secret Service"
 	outfit = /datum/outfit/job/enclave/intel
+	access = list(ACCESS_ENCLAVE, ACCESS_ENCLAVE_RD)
+	minimal_access = list(ACCESS_ENCLAVE, ACCESS_ENCLAVE_RD)
 	loadout_options = list(
 		/datum/outfit/loadout/observationist,
 		/datum/outfit/loadout/infiltrator,
@@ -240,6 +240,8 @@
 	selection_color = "#323232"
 	exp_requirements = 180
 	outfit = /datum/outfit/job/enclave/armor
+	access = list(ACCESS_ENCLAVE, ACCESS_ENCLAVE_RD)
+	minimal_access = list(ACCESS_ENCLAVE, ACCESS_ENCLAVE_RD)
 	loadout_options = list(
 		/datum/outfit/loadout/hammer,
 		/datum/outfit/loadout/support,

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -792,7 +792,6 @@
 	lefthand_file = 'icons/fallout/onmob/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/fallout/onmob/weapons/guns_righthand.dmi'
 	icon_state = "r91"
-	icon_state = "assault_rifle"
 	item_state = "fnfal"
 	mag_type = /obj/item/ammo_box/magazine/m556/rifle
 	fire_delay = 4


### PR DESCRIPTION
bug fixes for missing sprites (r91 assault rifle & enclave envirosuit hood)
swaps access 'ACCESS_ENCLAVE_RD' from being a science thing to being a command/intel thing in line with upcoming remap of the enclave base