### PR TITLE
sprite & flag bugfix

### DIFF
--- a/code/game/objects/items/fallout13misc.dm
+++ b/code/game/objects/items/fallout13misc.dm
@@ -168,6 +168,20 @@
 	item_state = "ncrflag"
 	faction = "NCR"
 
+/obj/item/flag/ncr
+	name = "Enclave Flag"
+	desc = "A flag with an 'E' and stars wrapped around it, the symbol of the Enclave."
+	icon_state = "enclaveflag"
+	item_state = "enclaveflag"
+	faction = "Enclave"
+
+/obj/item/flag/usa
+	name = "US Flag"
+	desc = "The star spangled banner."
+	icon_state = "usaflag"
+	item_state = "usaflag"
+	faction = "Enclave"
+
 /obj/item/flag/bos
 	name = "Brotherhood of Steel flag"
 	desc = "A red and black flag with a sword surrounded in gears and wings, in a dazzling gold."

--- a/code/modules/clothing/gloves/f13gloves.dm
+++ b/code/modules/clothing/gloves/f13gloves.dm
@@ -51,6 +51,7 @@
 /obj/item/clothing/gloves/f13/military/remnant
 	name = "Light Infantry Combat Gloves"
 	desc = "Tight fitting green ballistic gloves with mesh along the finger tips and padding along the palm. The craftsmanship is beyond what most in the wasteland could achieve, belonging to some kind of soldier."
+	icon = 'icons/fallout/clothing/gloves.dmi'
 	icon_state = "enclave_gloves"
 	item_state = "enclave_gloves"
 

--- a/code/modules/clothing/head/f13factionhead.dm
+++ b/code/modules/clothing/head/f13factionhead.dm
@@ -246,7 +246,7 @@
 	desc = "(I) Blue beret signifying the wearer is a Science Officer of the Enclave."
 	icon_state = "hat_enclave_science"
 	item_state = "hat_enclave_science"
-	flags_inv = HIDEEARS|HIDEFACE
+	flags_inv = HIDEEARS
 	flags_cover = null
 	armor = list("tier" = 1, "energy" = 10, "bomb" = 10, "bio" = 10, "rad" = 10, "fire" = 50, "acid" = 0)
 
@@ -264,7 +264,7 @@
 	desc = "(I) Dark beret issued to Intelligence Officers of the Enclave."
 	icon_state = "hat_enclave_intel"
 	item_state = "hat_enclave_intel"
-	flags_inv = HIDEEARS|HIDEFACE
+	flags_inv = HIDEEARS
 	flags_cover = null
 	armor = list("tier" = 1, "energy" = 10, "bomb" = 10, "bio" = 10, "rad" = 10, "fire" = 50, "acid" = 0)
 
@@ -273,9 +273,9 @@
 	desc = "(IV) Reinforced field cap issued to the soldiers of the Enclave."
 	icon_state = "hat_enclave_peacekeeper"
 	item_state = "hat_enclave_peacekeeper"
-	flags_inv = HIDEEARS|HIDEFACE
+	flags_inv = HIDEEARS
 	strip_delay = 50
-	armor = list("tier" = 4, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
+	armor = list("tier" = 1, "energy" = 10, "bomb" = 10, "bio" = 10, "rad" = 10, "fire" = 50, "acid" = 0)
 
 /obj/item/clothing/head/helmet/f13/remnant/officer
 	name = "enclave officer hat"
@@ -290,8 +290,7 @@
 	icon_state = "envirohead"
 	item_state = "envirohead"
 	desc = "(II) A white hazmat helmet with a coupling system, the visor looks to be made out of orange plexiglas."
-	icon = 'icons/fallout/clothing/hats.dmi'
-	mob_overlay_icon = 'icons/fallout/onmob/clothes/head.dmi'
+	mob_overlay_icon = 'icons/mob/clothing/head.dmi'
 	clothing_flags = THICKMATERIAL
 	flags_inv = HIDEMASK|HIDEEARS|HIDEFACE|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR
 	armor = list("tier" = 2,"energy" = 10, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 50, "acid" = 100)

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -15,6 +15,7 @@
 /obj/item/clothing/mask/gas/enclave
 	name = "US Army Combat Respirator"
 	desc = "A well maintained/ reproduced pre-war combat respirator designed to protect it's user from chemical, biological, radiological & nuclear threats on the battlefield."
+	icon = 'icons/fallout/clothing/masks.dmi'
 	icon_state = "enclave_gasmask"
 	item_state = "enclave_gasmask"
 	flash_protect = 2

--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -38,9 +38,9 @@
 	flag = F13USSCIENTIST
 	total_positions = 1
 	spawn_positions = 1
-	description = "You are in command of the Enclave outpost here, conduct research and help rebuild America by using your brains rather than your, admittedly impressive, military resources.."
+	description = "You are in command of the post, holding the rank of First Lieutenant- albiet honourably, the Sergeants have command in any sort of combat scenario. Conduct research and help rebuild America with your Scientists aswell as any research you wish to pursuit, utilise any resources available to you to achieve this."
 	forbids = "The Enclave forbids you from leaving the base alone while it is still habitable."
-	supervisors = "the United States Government."
+	supervisors = "Enclave Research and Development Division."
 	selection_color = "#323232"
 	exp_requirements = 180
 	access = list(ACCESS_ENCLAVE, ACCESS_ENCLAVE_RD)
@@ -58,7 +58,7 @@
 	gloves =	/obj/item/clothing/gloves/color/latex/nitrile
 	uniform =	/obj/item/clothing/under/f13/enclave
 	suit =	/obj/item/clothing/suit/armor/f13/environmentalsuit
-	accessory =	/obj/item/clothing/accessory/armband/science
+	accessory =	/obj/item/clothing/accessory/ncr/LT1
 	belt =	/obj/item/storage/belt/medical
 	suit_store =	/obj/item/tank/internals/oxygen
 
@@ -92,10 +92,9 @@
 	faction = "Enclave"
 	total_positions = 2
 	spawn_positions = 2
-	description = "You're responsible for the maintenance of the base, the knowledge you've accumulated over the years is the only thing keeping the remnants alive. You've dabbled in enough to be considered a Professor in proficiency, but they call you Doctor. Support your dwindling forces and listen to the Lieutenant."
+	description = "You are a Scientist, this post was constructed to assist you, and your division in field research, you're free to pick a topic or subject of research and utilise any resources at hand to achieve your goals in regards to this- though you should run it by the Research Director first."
 	forbids = "The Enclave forbids you from leaving the base alone while it is still habitable."
-	enforces = "You must maintain the secrecy of organization."
-	supervisors = "the United States Government."
+	supervisors = "Enclave Research and Development Division."
 	selection_color = "#323232"
 	outfit = /datum/outfit/job/enclave/scientist
 
@@ -141,8 +140,8 @@
 	faction = "Enclave"
 	total_positions = 2
 	spawn_positions = 2
-	description = "You are a US Secret Service Operative broadly tasked with ensuring the continued existence of your current post, you're free to assist the scientists, go completely undercover within another organisation, or simply act as a Paramedic for local forces."
-	supervisors = "The United States Secret Service"
+	description = "You are a US Secret Service agent broadly tasked with ensuring the continued existence of your post, you're free to assist the scientists, go completely undercover, or simply act as a Paramedic for local forces."
+	supervisors = "United States Secret Service."
 	outfit = /datum/outfit/job/enclave/intel
 	access = list(ACCESS_ENCLAVE, ACCESS_ENCLAVE_RD)
 	minimal_access = list(ACCESS_ENCLAVE, ACCESS_ENCLAVE_RD)
@@ -233,16 +232,17 @@
 	flag = F13USSGT
 	total_positions = 2
 	spawn_positions = 2
-	description = "Entrusted with both the now rare advanced armor and command of a squad, your nation relies on you doing your job."
-	supervisors = "the Director and the United States Government."
+	description = "Entrused with the command of the squads assigned to your bunker, your job is to assist the Research Director alongside the scientists, though you are given full command in any combat scenario."
+	supervisors = "Enclave Department of the Army."
 	selection_color = "#323232"
 	exp_requirements = 180
 	outfit = /datum/outfit/job/enclave/armor
 	access = list(ACCESS_ENCLAVE, ACCESS_ENCLAVE_RD)
 	minimal_access = list(ACCESS_ENCLAVE, ACCESS_ENCLAVE_RD)
 	loadout_options = list(
-		/datum/outfit/loadout/hammer,
+		/datum/outfit/loadout/shocktrooper,
 		/datum/outfit/loadout/support,
+		/datum/outfit/loadout/sniper,
 		)
 
 
@@ -273,8 +273,8 @@
 	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
 	ADD_TRAIT(H, TRAIT_PA_WEAR, src)
 
-/datum/outfit/loadout/hammer
-	name = "Hammer."
+/datum/outfit/loadout/shocktrooper
+	name = "Shocktrooper"
 	suit_store = /obj/item/twohanded/sledgehammer/supersledge
 	backpack_contents = list(
 		/obj/item/gun/energy/laser/plasma/pistol = 1,
@@ -291,6 +291,15 @@
 		/obj/item/ammo_box/shotgun/buck = 1,
 		)
 
+/datum/outfit/loadout/sniper
+	name = "Sniper"
+	suit_store = /obj/item/gun/energy/laser/aer12
+	backpack_contents = list(
+		/obj/item/attachments/scope = 1,
+		/obj/item/stock_parts/cell/ammo/mfc = 3,
+		/obj/item/gun/ballistic/revolver/ballisticfist = 1,
+		/obj/item/ammo_box/shotgun/buck = 1,
+		)
 
 /*-------------------- ENCLAVE CORPORAL -----------------------*/
 // NCO
@@ -300,8 +309,8 @@
 	flag = F13USCORPORAL
 	total_positions = 2
 	spawn_positions = 2
-	description = "You are a member of a dying breed, true Americans, but you will do what you can to help revitalize the nation, and protect her from all enemies, foreign and domestic."
-	supervisors = "You report to the Sergeants directly."
+	description = "You are a Corporal, you report directly to your Sergeants and command the Privates under you."
+	supervisors = "Enclave Department of the Army."
 	selection_color = "#323232"
 	outfit = /datum/outfit/job/enclave/corporal
 	loadout_options = list(
@@ -360,8 +369,8 @@
 	flag = F13USPRIVATE
 	total_positions = 4
 	spawn_positions = 4
-	description = "You are a member of a dying breed, true Americans, but you will do what you can to help revitalize the nation, and protect her from all enemies, foreign and domestic."
-	supervisors = "The Corporals, alongside the Sergeants."
+	description = "You are a Private, you report directly to your Corporals, who in turn take orders from the Sergeants."
+	supervisors = "Enclave Department of the Army."
 	selection_color = "#323232"
 	outfit = /datum/outfit/job/enclave/soldier
 	loadout_options = list(

--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -52,7 +52,7 @@
 	name =	"Enclave Research Director"
 	jobtype =	/datum/job/enclave/director
 	head =	/obj/item/clothing/head/helmet/f13/remnant/envirosuit
-	glasses =	/obj/item/clothing/glasses/meson
+	glasses =	/obj/item/clothing/glasses/science
 	mask =	/obj/item/clothing/mask/breath/medical
 	neck =	/obj/item/storage/belt/holster/legholster/aep7
 	gloves =	/obj/item/clothing/gloves/color/latex/nitrile
@@ -64,7 +64,6 @@
 
 	backpack_contents = list(
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 2,
-		/obj/item/grenade/chem_grenade/cleaner = 1,
 		/obj/item/storage/bag/money/small/ncr = 1,
 		/obj/item/clothing/head/helmet/f13/helmet/enclave/science = 1,
 		/obj/item/reagent_containers/food/snacks/f13/mre/remnant = 1,
@@ -105,7 +104,7 @@
 	jobtype =	/datum/job/enclave/scientist
 	head =	/obj/item/clothing/head/helmet/f13/remnant/envirosuit
 	neck =	/obj/item/storage/belt/holster/legholster/aep7
-	glasses =	/obj/item/clothing/glasses/meson
+	glasses =	/obj/item/clothing/glasses/hud/health
 	mask =	/obj/item/clothing/mask/breath/medical
 	gloves =	/obj/item/clothing/gloves/color/latex/nitrile
 	uniform =	/obj/item/clothing/under/f13/enclave
@@ -116,7 +115,6 @@
 
 	backpack_contents = list(
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 2,
-		/obj/item/grenade/chem_grenade/cleaner = 1,
 		/obj/item/storage/bag/money/small/ncrofficers = 1,
 		/obj/item/clothing/head/helmet/f13/helmet/enclave/science = 1,
 		/obj/item/reagent_containers/food/snacks/f13/mre/remnant = 1,
@@ -161,7 +159,6 @@
 	name =	"Intelligence Specialist"
 	jobtype =	/datum/job/enclave/intel
 	head =	/obj/item/clothing/head/helmet/f13/remnant/intel
-	glasses = /obj/item/clothing/glasses/night/polarizing
 	uniform =	/obj/item/clothing/under/f13/enclave/intel
 	suit =	/obj/item/clothing/suit/armor/f13/combat/swat
 	suit_store =	/obj/item/gun/ballistic/automatic/pistol/n99/enclave
@@ -189,6 +186,7 @@
 		/obj/item/encryptionkey/headset_vault = 1,
 		/obj/item/jammer = 1,
 		/obj/item/binoculars = 1,
+		/obj/item/clothing/glasses/night = 1,
 		/obj/item/clothing/mask/infiltrator = 1,
 		/obj/item/ammo_box/magazine/m10mm_adv/simple = 2,
 		)
@@ -253,6 +251,7 @@
 	jobtype = /datum/job/enclave/armor
 	head =	/obj/item/clothing/head/helmet/f13/remnant/army
 	neck =	/obj/item/storage/belt/holster/legholster
+	glasses = /obj/item/clothing/glasses/night
 	mask =	/obj/item/clothing/mask/gas/enclave
 	uniform =	/obj/item/clothing/under/f13/enclave
 	suit =	/obj/item/clothing/suit/armor/f13/enclave/army
@@ -278,7 +277,7 @@
 	name = "Hammer."
 	suit_store = /obj/item/twohanded/sledgehammer/supersledge
 	backpack_contents = list(
-		/obj/item/gun/energy/laser/plasma/glock = 1,
+		/obj/item/gun/energy/laser/plasma/pistol = 1,
 		/obj/item/stock_parts/cell/ammo/ec = 3,
 		/obj/item/book/granter/trait/bigleagues = 1,
 		)


### PR DESCRIPTION
-fixes a couple small bugs introduced with the recent PR (missing icons for enclave gloves & gasmask).
-properly defines the new flags, also enclave units now get the intended goggles (health HUD for scientists, science goggles for head researcher, NVGs for sergeant).
-redefines a lot of enclave mission descriptions & supervisors to be more lore friendly.
-swaps around some armour values and icons to be in line with new update aswell as /properly/ fixing envirohood.
-adds a new sergeant loadout (sniper, basically the same as the G11 loadout but you get an AER12 with a scope)